### PR TITLE
feat(seo): custom page sitemap via fetchCustomPages

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -20,6 +20,7 @@ export default hydrogenRoutes([
     ),
     route("sitemap.xml", "routes/seo/sitemap.ts"),
     route("sitemap/:type/:page.xml", "routes/seo/sitemap-page.ts"),
+    route("sitemap-weaverse.xml", "routes/seo/sitemap-weaverse.xml.ts"),
     route("pages/:pageHandle", "routes/pages/regular-page.tsx"),
     route("discount/:code", "routes/others/discount-code.tsx"),
     ...prefix("api", [

--- a/app/routes/seo/sitemap-page.ts
+++ b/app/routes/seo/sitemap-page.ts
@@ -4,7 +4,7 @@ import type { LoaderFunctionArgs } from "react-router";
 export async function loader({
   request,
   params,
-  context: { storefront },
+  context: { storefront, weaverse },
 }: LoaderFunctionArgs) {
   const response = await getSitemap({
     storefront,

--- a/app/routes/seo/sitemap-page.ts
+++ b/app/routes/seo/sitemap-page.ts
@@ -4,7 +4,7 @@ import type { LoaderFunctionArgs } from "react-router";
 export async function loader({
   request,
   params,
-  context: { storefront, weaverse },
+  context: { storefront },
 }: LoaderFunctionArgs) {
   const response = await getSitemap({
     storefront,

--- a/app/routes/seo/sitemap-weaverse.xml.ts
+++ b/app/routes/seo/sitemap-weaverse.xml.ts
@@ -1,0 +1,40 @@
+import type { LoaderFunctionArgs } from "react-router";
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function loader({ request, context }: LoaderFunctionArgs) {
+  const { weaverse } = context as any;
+  const url = new URL(request.url);
+  const baseUrl = `${url.protocol}//${url.host}`;
+
+  const entries = await weaverse.fetchCustomPages();
+
+  const urls = entries.map((entry) => {
+    const loc = escapeXml(`${baseUrl}${entry.path}`);
+    return `  <url>
+      <loc>${loc}</loc>
+      <lastmod>${escapeXml(entry.lastModified)}</lastmod>
+      <changefreq>${entry.changeFrequency || "weekly"}</changefreq>
+      <priority>${entry.priority ?? 0.7}</priority>
+    </url>`;
+  });
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join("\n")}
+</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": `max-age=${60 * 60 * 24}`,
+    },
+  });
+}

--- a/app/routes/seo/sitemap.ts
+++ b/app/routes/seo/sitemap.ts
@@ -10,6 +10,21 @@ export async function loader({
     request,
   });
 
-  response.headers.set("Cache-Control", `max-age=${60 * 60 * 24}`);
-  return response;
+  // Add Weaverse custom pages sitemap to the index
+  const sitemapXml = await response.text();
+  const url = new URL(request.url);
+  const weaverseSitemapUrl = `${url.protocol}//${url.host}/sitemap-weaverse.xml`;
+  
+  // Insert Weaverse sitemap before closing sitemapindex tag
+  const modifiedXml = sitemapXml.replace(
+    "</sitemapindex>",
+    `  <sitemap>\n    <loc>${weaverseSitemapUrl}</loc>\n  </sitemap>\n</sitemapindex>`
+  );
+
+  return new Response(modifiedXml, {
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": `max-age=${60 * 60 * 24}`,
+    },
+  });
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@shopify/hydrogen": "^2026.4.1",
     "@shopify/hydrogen-react": "^2026.4.1",
     "@tailwindcss/vite": "^4.2.2",
-    "@weaverse/hydrogen": "^5.12.0",
+    "@weaverse/hydrogen": "^5.13.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "colord": "2.9.3",


### PR DESCRIPTION
## Summary
- Rewrite `sitemap-weaverse.xml.ts` to use `weaverse.fetchCustomPages()` SDK method instead of directly calling the auth-gated content API
- Add XML escaping for all dynamic values
- Add `<lastmod>` from `publishedAt` timestamp
- Register route in `routes.ts` and inject into sitemap index in `sitemap.ts`

## Depends on
- Builder PR: Weaverse/builder#2226 (public endpoint)
- SDK PR: Weaverse/weaverse#445 (`fetchCustomPages` method)

## Test plan
- [ ] Verify `/sitemap-weaverse.xml` returns valid XML with custom pages
- [ ] Verify `/sitemap.xml` includes the weaverse sitemap reference
- [ ] Verify `<lastmod>` dates are present and correctly formatted
- [ ] Verify XML escaping works for special characters in handles