### PR TITLE
feat(weaverse): per-request projectId resolver + 24h cookie for Cloud Sandbox

### DIFF
--- a/app/.server/context.ts
+++ b/app/.server/context.ts
@@ -7,6 +7,7 @@ import {
   type SessionStorage,
 } from "react-router";
 import { CART_QUERY_FRAGMENT } from "~/graphql/fragments";
+import { readProjectIdFromCookie } from "~/lib/weaverse/resolve-project.server";
 import type { I18nLocale } from "~/types/others";
 import { COUNTRIES } from "~/utils/const";
 import { components } from "~/weaverse/components";
@@ -56,6 +57,13 @@ export async function createHydrogenRouterContext(
     cache,
     themeSchema,
     components,
+    // Multi-project resolution priority chain handled by the SDK:
+    //   1. ?weaverseProjectId=<id> query param (Studio iframe always sets this)
+    //   2. this function — reads a 24h cookie set by the response for
+    //      in-iframe navigation without the query string
+    //   3. env.WEAVERSE_PROJECT_ID (bare URL fallback)
+    // See app/lib/weaverse/resolve-project.server.ts and Phase 1.5c spec.
+    projectId: () => readProjectIdFromCookie(request),
   });
 
   // Add weaverse directly to the hydrogenContext instance

--- a/app/lib/weaverse/resolve-project.server.ts
+++ b/app/lib/weaverse/resolve-project.server.ts
@@ -1,0 +1,80 @@
+/**
+ * Per-request projectId resolution for cloud-sandbox-backed previews.
+ *
+ * The Weaverse Hydrogen SDK already resolves `?weaverseProjectId=<id>` from
+ * the URL with highest priority (see WeaverseClient.resolveProjectIdSync).
+ * What it does NOT do is persist that choice across subsequent navigation
+ * inside the iframe \u2014 once the user clicks a link and the query string is
+ * gone, the SDK falls through to `env.WEAVERSE_PROJECT_ID` and the wrong
+ * theme renders.
+ *
+ * This module bridges that gap with a small cookie:
+ *
+ *   1. {@link readProjectIdFromCookie} \u2014 used by `WeaverseClient`'s
+ *      `projectId` resolver as the priority-2 fallback (function). Returns
+ *      the cookie value when present, empty string otherwise (so the SDK
+ *      continues falling through to env on a miss).
+ *
+ *   2. {@link maybeSetProjectIdCookie} \u2014 called after the request handler
+ *      returns. If the URL contained `?weaverseProjectId=<id>`, mints a
+ *      Set-Cookie header with a 24h max-age so the next nav without the
+ *      query string still resolves the same project.
+ *
+ * Studio iframe rule (Phase 1 spec): Studio ALWAYS sets the query string
+ * explicitly when loading the preview iframe. The cookie is a fallback for
+ * in-iframe navigation only, never trusted cross-tab. Phase 1.5 spec:
+ * .specs/2026-05-12--cloud-sandbox-phase-1/README.md
+ */
+
+const COOKIE_NAME = "weaverseProjectId";
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24; // 24h
+// Project IDs are CUID-shape today (alphanumeric + hyphens + underscores).
+// Mirrors the validation in @weaverse/hydrogen's WeaverseClient. Reject
+// anything else so a poisoned cookie can't inject arbitrary header bytes.
+const VALID_PROJECT_ID = /^[a-zA-Z0-9_-]{1,128}$/;
+
+export function readProjectIdFromCookie(request: Request): string {
+  const header = request.headers.get("Cookie");
+  if (!header) return "";
+
+  // Hand-rolled parse \u2014 small enough that pulling in cookie lib is overkill,
+  // and we already validate format on the way out anyway.
+  for (const part of header.split(";")) {
+    const [rawName, ...rawValue] = part.trim().split("=");
+    if (rawName !== COOKIE_NAME) continue;
+    const value = decodeURIComponent(rawValue.join("=") ?? "");
+    return VALID_PROJECT_ID.test(value) ? value : "";
+  }
+  return "";
+}
+
+/**
+ * If the request URL contains `?weaverseProjectId=<id>`, append a Set-Cookie
+ * header to `response` so subsequent navigation in the same iframe keeps
+ * using that project.
+ *
+ * No-op if the query param is absent or the value is malformed. Existing
+ * Set-Cookie headers (session, cart, etc.) are preserved by using append().
+ */
+export function maybeSetProjectIdCookie(
+  request: Request,
+  response: Response,
+): void {
+  const url = new URL(request.url);
+  const incoming = url.searchParams.get("weaverseProjectId");
+  if (!incoming || !VALID_PROJECT_ID.test(incoming)) return;
+
+  // SameSite=Lax is fine: Studio iframe lives on a different origin
+  // (studio.weaverse.io) but the cookie is for the sandbox origin
+  // (<handle>.weaverse.dev) which IS the top-level navigation when the
+  // SDK reads it. Strict would break in-iframe nav.
+  const cookie = [
+    `${COOKIE_NAME}=${encodeURIComponent(incoming)}`,
+    "Path=/",
+    `Max-Age=${COOKIE_MAX_AGE_SECONDS}`,
+    "SameSite=Lax",
+    "Secure",
+    "HttpOnly",
+  ].join("; ");
+  response.headers.append("Set-Cookie", cookie);
+}

--- a/server.ts
+++ b/server.ts
@@ -2,6 +2,7 @@ import * as remixBuild from "virtual:react-router/server-build"; // Virtual entr
 import { storefrontRedirect } from "@shopify/hydrogen";
 import { createRequestHandler } from "@shopify/hydrogen/oxygen";
 import { createHydrogenRouterContext } from "~/.server/context";
+import { maybeSetProjectIdCookie } from "~/lib/weaverse/resolve-project.server";
 
 /**
  * Export a fetch handler in module format.
@@ -37,6 +38,13 @@ export default {
           await hydrogenContext.session.commit(),
         );
       }
+
+      // Phase 1.5c: if URL had ?weaverseProjectId=<id>, persist for 24h so
+      // in-iframe navigation without the query string keeps the same project.
+      // Must run AFTER the session commit — that commit uses .set() (not
+      // .append()) on the Set-Cookie header, which would clobber a cookie
+      // appended earlier. .append() here preserves the session cookie above.
+      maybeSetProjectIdCookie(request, response);
 
       if (response.status === 404) {
         /**


### PR DESCRIPTION
## Summary

Phase 1.5 Slice 1.5c of [Weaverse/builder#2222](https://github.com/Weaverse/builder/issues/2222) (Cloud Sandbox).

A single sandbox machine serves multiple projects (M:N preview model from [builder#2326](https://github.com/Weaverse/builder/pull/2326)). The Weaverse Hydrogen SDK already resolves `?weaverseProjectId=<id>` from the URL query with highest priority — the missing piece is that once the user clicks an in-iframe link and the query string disappears, the SDK falls through to `env.WEAVERSE_PROJECT_ID` and the wrong theme renders.

This PR adds a tiny cookie bridge: ~95 LOC, 3 files, zero SDK changes.

## How it fits the SDK's existing priority chain

```
@weaverse/hydrogen's projectId resolution (already shipping in v5.13+):

  1. ?weaverseProjectId=<id> URL param   ← Studio iframe ALWAYS sets this
  2. projectId function arg              ← THIS PR plugs in here
  3. projectId string arg
  4. env.WEAVERSE_PROJECT_ID             ← bare URL fallback
```

Slot 2 was unused. We fill it with `() => readProjectIdFromCookie(request)`. Cookie is set on the way out whenever slot 1 fires, so in-iframe navigation after the initial load (which loses the query string) still resolves the same project.

## Files

| File | What |
|---|---|
| `app/lib/weaverse/resolve-project.server.ts` (new) | `readProjectIdFromCookie` + `maybeSetProjectIdCookie`. ~75 LOC. |
| `app/.server/context.ts` | Pass `projectId: () => readProjectIdFromCookie(request)` to `WeaverseClient`. |
| `server.ts` | After response, call `maybeSetProjectIdCookie(request, response)`. |

## Why the call is AFTER session.commit()

This is the subtle bit. `server.ts` already does:

```ts
response.headers.set("Set-Cookie", await hydrogenContext.session.commit())
```

`.set()` (not `.append()`) clobbers any existing `Set-Cookie` header. If I `.append()` my project cookie before that line, it gets nuked.

So the order is:
1. `handleRequest` → response built
2. `session.commit()` → session cookie `.set()`
3. `maybeSetProjectIdCookie` → project cookie `.append()`

Both cookies ride along on the same response. There's an inline comment in `server.ts` documenting this so a future refactor doesn't reorder them.

## Security

- Cookie value validated against `/^[a-zA-Z0-9_-]{1,128}$/` on **both** read and write paths. Poisoned cookies silently return `''`, falling through to env.
- Cookie flags: `Max-Age=86400; Path=/; SameSite=Lax; Secure; HttpOnly`
  - **`Lax` over `Strict`**: cookie is for the sandbox origin (`<handle>.weaverse.dev`) which IS top-level when the SDK reads it. Strict would break in-iframe nav.
  - **`HttpOnly`**: not strictly needed (we never read client-side) but defense-in-depth.
- Studio iframe always sets the explicit `?weaverseProjectId=` query param when loading (per Phase 1.5 spec). Cookie is a fallback for in-iframe nav only, **never trusted cross-tab**.

## Test plan

- [x] `npm run typecheck` — 1 pre-existing error (bun cache duplicate `@shopify/hydrogen` versions, unrelated, present on bare `main`), **0 new**.
- [x] `npm run biome` — 3 `useBlockStatements` style warnings, exit 0.
- [ ] **Smoke test (manual, post-merge):** load `<handle>.weaverse.dev/?weaverseProjectId=A`, click an in-iframe link, confirm the response still uses project A (not env default). Then load `<handle>.weaverse.dev/?weaverseProjectId=B`, confirm cookie is updated and B renders.

### Why no unit tests

Pilot uses Playwright e2e only; no unit-test runner is configured. The module is small (regex + cookie parse + `Set-Cookie` header build). Real traffic from Phase 1.5d onward will exercise it within a few days of merge. Adding a Vitest setup just for this would be scope creep.

If you want me to add a Vitest setup anyway, happy to in a follow-up — but for one 75 LOC module on a tight schedule, the cost-benefit doesn't pencil out.

## Rollout

Deploys to the `weaverse-sandbox` Pilot theme image. Once merged, the next `bun run build-theme.sh` in `weaverse-sandbox` picks it up and bakes it into a new theme image digest. Then the next sandbox machine boot uses it. Existing running sandboxes pick it up on next image refresh.

**No breaking changes** for non-sandbox Pilot deployments — the cookie is only ever read when set, and only ever set when the query param is present.

Refs `Weaverse/builder#2222` Phase 1.5 Slice 1.5c. Spec: `Weaverse/builder/.specs/2026-05-12--cloud-sandbox-phase-1/README.md`.

Stacks logically on:
- [Weaverse/builder#2326](https://github.com/Weaverse/builder/pull/2326) (schema)
- [Weaverse/builder#2327](https://github.com/Weaverse/builder/pull/2327) (API)

Independent at the git level — this can merge any time.
