### PR TITLE
fix(checkout): forward ad-attribution URL params to checkout

### DIFF
--- a/app/components/cart/cart-summary.tsx
+++ b/app/components/cart/cart-summary.tsx
@@ -8,7 +8,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { CartForm, Money, type OptimisticCart } from "@shopify/hydrogen";
 import { useThemeSettings } from "@weaverse/hydrogen";
 import clsx from "clsx";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import type { CartApiQueryFragment } from "storefront-api.generated";
 import { Button } from "~/components/button";
@@ -17,6 +17,7 @@ import { Skeleton } from "~/components/skeleton";
 import { Spinner } from "~/components/spinner";
 import type { CartLayoutType } from "~/types/others";
 import type { ThemeSettings } from "~/types/weaverse";
+import { appendForwardedAttribution } from "~/utils/checkout-attribution";
 import { cn } from "~/utils/cn";
 import {
   DiscountDialog,
@@ -57,6 +58,26 @@ export function CartSummary({
     appliedGiftCards,
     note,
   } = cart;
+
+  // Append ad-attribution params from the current storefront URL onto
+  // the checkout URL so Shopify's built-in tracking on the checkout
+  // subdomain sees consistent last-click identifiers (gclid, fbclid,
+  // utm_*, …). The initial render uses the unmodified checkoutUrl so
+  // SSR + client first-paint match; once the browser hydrates we swap
+  // in the enhanced URL via state. Server-side direct redirects (the
+  // Buy-now flow in app/routes/cart/lines.tsx) handle this server-side
+  // and don't go through this component.
+  const [enhancedCheckoutUrl, setEnhancedCheckoutUrl] = useState(checkoutUrl);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: recompute whenever the underlying checkoutUrl changes
+  useEffect(() => {
+    if (typeof window === "undefined" || !checkoutUrl) {
+      setEnhancedCheckoutUrl(checkoutUrl);
+      return;
+    }
+    setEnhancedCheckoutUrl(
+      appendForwardedAttribution(checkoutUrl, window.location.search),
+    );
+  }, [checkoutUrl]);
 
   // Show loading state for optimistic line item changes or pending cart actions
   const isCartUpdating =
@@ -242,7 +263,7 @@ export function CartSummary({
       )}
       {checkoutUrl && (
         <div className="mt-2 flex flex-col gap-3">
-          <a href={checkoutUrl} target="_self">
+          <a href={enhancedCheckoutUrl} target="_self">
             <Button className="w-full">
               <span>{checkoutButtonText || "Continue to Checkout"}</span>
               {layout === "drawer" && (

--- a/app/routes/cart/lines.tsx
+++ b/app/routes/cart/lines.tsx
@@ -1,5 +1,6 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect } from "react-router";
+import { appendForwardedAttribution } from "~/utils/checkout-attribution";
 
 /**
  * Automatically creates a new cart based on the URL and redirects straight to checkout.
@@ -59,7 +60,17 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
 
   //! redirect to checkout
   if (cartResult.checkoutUrl) {
-    return redirect(cartResult.checkoutUrl, { headers });
+    // Forward ad-attribution params (gclid, fbclid, utm_*, …) from the
+    // storefront URL to the checkout URL so Shopify's built-in tracking
+    // on the checkout subdomain sees the same last-click identifiers.
+    // Without this, every paid-ad Buy-now order lands on checkout with
+    // organic / direct attribution. No-op when no such params are
+    // present on the incoming URL.
+    const incoming = new URL(request.url);
+    return redirect(
+      appendForwardedAttribution(cartResult.checkoutUrl, incoming.search),
+      { headers },
+    );
   }
   throw new Error("No checkout URL found");
 }

--- a/app/utils/checkout-attribution.ts
+++ b/app/utils/checkout-attribution.ts
@@ -1,0 +1,89 @@
+/**
+ * Forward ad-attribution URL parameters from the storefront onto the
+ * Shopify checkout URL.
+ *
+ * Hydrogen storefronts live on one origin (e.g. `mystore.com`) and the
+ * Shopify checkout lives on another (e.g. `checkout.mystore.com` or
+ * `mystore.myshopify.com`). When a buyer arrives via a paid ad and the
+ * landing URL carries identifiers like `?gclid=...` or `?utm_source=...`,
+ * those identifiers stay on the storefront's URL only — they do NOT
+ * automatically propagate to the checkout subdomain. Shopify's built-in
+ * Customer Events / GA4 / Meta Pixel running on the checkout origin then
+ * see organic / direct traffic, silently breaking last-click attribution
+ * for every paid order.
+ *
+ * The fix is small and universal: whenever we hand the buyer off to the
+ * Shopify checkout URL (either via the regular cart's "Continue to
+ * Checkout" link or via Shopify's cart-permalink Buy-now flow), append
+ * the standard set of attribution params from the storefront's current
+ * URL onto the outbound checkout URL. The checkout's own tracking then
+ * sees the same identifiers and ad-platform reports stay accurate.
+ *
+ * Existing params on the checkout URL are never overwritten — if the
+ * caller already set something explicitly, that value wins.
+ */
+
+/**
+ * The set of well-known ad / click / UTM identifiers worth forwarding.
+ *
+ * Limited to widely-recognised standard params on purpose — affiliate /
+ * vendor-specific click IDs (e.g. `tj_clickid`, `awc`, `irclickid`) tend
+ * to live in a first-party attribution cookie scoped to the apex domain
+ * rather than on every checkout URL, so they don't need to round-trip
+ * here. If your storefront also captures custom identifiers in URL
+ * params, extend this list.
+ */
+export const FORWARDED_ATTRIBUTION_KEYS = [
+  // Google / Bing / TikTok / Meta click IDs
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "fbclid",
+  "ttclid",
+  "msclkid",
+  // UTM
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
+/**
+ * Returns `checkoutUrl` with attribution params from `searchString`
+ * appended (first-write-wins on key collisions — never clobbers params
+ * the caller already set on the checkout URL).
+ *
+ * Falls back to the original `checkoutUrl` unchanged if either input
+ * can't be parsed as a URL, so a malformed input never breaks the
+ * checkout redirect.
+ *
+ * @param checkoutUrl   the outbound Shopify checkout URL
+ * @param searchString  the storefront's current URL query string
+ *                      (e.g. `request.url`'s search on the server, or
+ *                      `window.location.search` in the browser)
+ */
+export function appendForwardedAttribution(
+  checkoutUrl: string,
+  searchString: string,
+): string {
+  if (!checkoutUrl) return checkoutUrl;
+  if (!searchString) return checkoutUrl;
+
+  let target: URL;
+  try {
+    target = new URL(checkoutUrl);
+  } catch {
+    return checkoutUrl;
+  }
+
+  const incoming = new URLSearchParams(searchString);
+  for (const key of FORWARDED_ATTRIBUTION_KEYS) {
+    const value = incoming.get(key);
+    if (value && value.trim() !== "" && !target.searchParams.has(key)) {
+      target.searchParams.set(key, value.trim());
+    }
+  }
+
+  return target.toString();
+}


### PR DESCRIPTION
## Summary

Forward ad-attribution URL params (`gclid`, `fbclid`, `utm_*`, …) from the storefront onto the outbound Shopify checkout URL so Shopify's built-in tracking on the checkout subdomain sees consistent last-click identifiers.

## The problem

Hydrogen storefronts live on one origin (`mystore.com`) and Shopify checkout lives on another (`checkout.mystore.com` or `mystore.myshopify.com`). When a buyer arrives via a paid ad and the landing URL carries identifiers like `?gclid=...`, `?fbclid=...`, or `?utm_source=...`, those identifiers stay on the storefront's URL only — they do **NOT** automatically propagate to the checkout subdomain.

Shopify's built-in tracking running on the checkout origin (Customer Events, GA4, Meta Pixel) then sees the checkout-page URL with no attribution params, and reports every paid-ad order as **organic / direct**. Last-click attribution silently breaks for every paid order — the kind of bug that's invisible in acceptance tests and only surfaces weeks later when ad-platform reports stop matching reality.

Two cart → checkout transition points are affected:

1. **Regular cart**: "Continue to Checkout" `<a href={cart.checkoutUrl}>` link in `app/components/cart/cart-summary.tsx`.
2. **Buy-now / cart-permalink flow**: `app/routes/cart/lines.tsx` loader for `/cart/<variantId>:<qty>?checkout` URLs that `cart.create()` + `redirect()` straight to checkout.

Both currently hand off the raw `cart.checkoutUrl` with no attribution forwarding.

## The fix

A small, self-contained helper:

```ts
// app/utils/checkout-attribution.ts
export function appendForwardedAttribution(
  checkoutUrl: string,
  searchString: string,
): string;
```

…wired into both transition points. The helper:

- Forwards `gclid`, `gbraid`, `wbraid`, `fbclid`, `ttclid`, `msclkid`, and the five `utm_*` params (deliberately scoped to widely-recognised standard params; affiliate / vendor-specific click IDs usually live in first-party cookies scoped to the apex domain and don't need this URL round-trip).
- **First-write-wins** — never overwrites params already on the checkout URL.
- Falls back to the original `checkoutUrl` unchanged on parse failure so a malformed input never breaks the checkout redirect.

### `lines.tsx` (Buy-now)

Pure server-side — reads `request.url`'s search and forwards before the `redirect()`. No client step.

### `cart-summary.tsx` (Continue to Checkout link)

Reads `window.location.search` after hydration via `useEffect` and swaps the link's `href` to the enhanced URL. **First render uses the raw `checkoutUrl`** so SSR + client first-paint stay consistent (no hydration mismatch warning).

## Verification

1. Visit `https://yourstore.com/?utm_source=test&gclid=GCL_TEST_001`.
2. Add an item to cart → "Continue to Checkout".
3. The outbound link now points to `…?…&utm_source=test&gclid=GCL_TEST_001`.
4. Shopify checkout's Customer Events / GA4 / Meta Pixel pick up the params.

For the Buy-now path, use a "Buy now" button on a PDP (any Pilot derivative that wires the `showBuyNowButton` schema option) and confirm the redirect destination carries the params.

## What this does NOT do

- **Doesn't add server-side conversion forwarders** (Meta CAPI, GA4 Measurement Protocol, Google Ads Enhanced Conversions). Those need a separate cart-attribute-stash pattern to bridge the cookie-less webhook hop — that's a much bigger contribution. This PR fixes only the checkout-side tracking that Shopify gives you out of the box.
- **Doesn't introduce any new cookie**. Pure URL → URL pass-through.
- **Doesn't require opt-in** — every Pilot user with paid traffic benefits immediately.

## Out of scope / future work

Storefronts capturing affiliate or vendor-specific click IDs (Traffic Junky `tj_clickid`, Awin `awc`, Impact Radius `irclickid`, etc.) usually round-trip them through a first-party attribution cookie scoped to the apex domain — a separate concern from this URL-only pass-through. Users can extend `FORWARDED_ATTRIBUTION_KEYS` in user-space if needed.

## Files

- ➕ `app/utils/checkout-attribution.ts` (new, ~90 lines incl. JSDoc)
- ✏️ `app/routes/cart/lines.tsx` (+10 LOC)
- ✏️ `app/components/cart/cart-summary.tsx` (+20 LOC)

Net diff: ~124 insertions, 3 deletions. No new dependencies.
