### PR TITLE
perf: eager-load above-the-fold section backgrounds (LCP fix)

### DIFF
--- a/app/components/background-image.tsx
+++ b/app/components/background-image.tsx
@@ -30,20 +30,31 @@ const variants = cva("absolute inset-0 z-[-1] h-full w-full", {
 
 export type BackgroundImageProps = VariantProps<typeof variants> & {
   backgroundImage?: WeaverseImage | string;
+  /**
+   * Above-the-fold sections (hero-image, first slideshow slide) must render
+   * their background eagerly: section backgrounds are the LCP element on
+   * most Weaverse pages, and the default lazy loading defers the LCP fetch
+   * until after layout (measured 13.6s mobile LCP on the demo homepage).
+   */
+  loading?: "eager" | "lazy";
 };
-
 export function BackgroundImage(props: BackgroundImageProps) {
-  const { backgroundImage, backgroundFit, backgroundPosition } = props;
+  const { backgroundImage, backgroundFit, backgroundPosition, loading } = props;
   if (backgroundImage) {
     const data =
       typeof backgroundImage === "string"
         ? { url: backgroundImage, altText: "Section background" }
         : backgroundImage;
+    const eager = loading === "eager";
     return (
       <Image
         className={variants({ backgroundFit, backgroundPosition })}
         data={data}
-        sizes="auto"
+        loading={loading}
+        fetchPriority={eager ? "high" : undefined}
+        // `sizes="auto"` is only valid for lazy images (browser uses layout
+        // size); eager backgrounds are full-bleed, so 100vw is correct.
+        sizes={eager ? "100vw" : "auto"}
       />
     );
   }

--- a/app/components/overlay-and-background.tsx
+++ b/app/components/overlay-and-background.tsx
@@ -12,6 +12,7 @@ export function OverlayAndBackground(props: OverlayAndBackgroundProps) {
     backgroundImage,
     backgroundFit,
     backgroundPosition,
+    loading,
     enableOverlay,
     overlayColor,
     overlayColorHover,
@@ -23,6 +24,7 @@ export function OverlayAndBackground(props: OverlayAndBackgroundProps) {
         backgroundImage={backgroundImage}
         backgroundFit={backgroundFit}
         backgroundPosition={backgroundPosition}
+        loading={loading}
       />
       <Overlay
         enableOverlay={enableOverlay}

--- a/app/components/section.tsx
+++ b/app/components/section.tsx
@@ -77,6 +77,7 @@ export function Section(props: SectionProps) {
     backgroundImage,
     backgroundFit,
     backgroundPosition,
+    loading,
     enableOverlay,
     overlayColor,
     overlayColorHover,

--- a/app/sections/hero-image.tsx
+++ b/app/sections/hero-image.tsx
@@ -61,6 +61,9 @@ export default function HeroImage(props: HeroImageProps & SectionProps) {
   return (
     <Section
       {...rest}
+      // Hero backgrounds are above the fold — eager + high-priority fetch
+      // so the LCP image isn't deferred by the default lazy loading.
+      loading="eager"
       containerClassName={variants({
         contentPosition,
         height,

--- a/app/sections/slideshow/index.tsx
+++ b/app/sections/slideshow/index.tsx
@@ -5,6 +5,7 @@ import {
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
 import clsx from "clsx";
+import { cloneElement, isValidElement, type ReactElement } from "react";
 import { Autoplay, EffectFade, Navigation, Pagination } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { ScrollReveal } from "~/components/scroll-reveal";
@@ -134,7 +135,13 @@ export default function Slideshow(
       >
         {children.map((child, idx) => (
           <SwiperSlide key={idx} className="bg-white">
-            {child}
+            {/* The first slide is the LCP element on slideshow-led pages —
+                its background must load eagerly with high priority. */}
+            {isValidElement(child) && idx === 0
+              ? cloneElement(child as ReactElement<{ loading?: string }>, {
+                  loading: "eager",
+                })
+              : child}
           </SwiperSlide>
         ))}
         {showArrows && (

--- a/app/sections/slideshow/slide.tsx
+++ b/app/sections/slideshow/slide.tsx
@@ -74,6 +74,7 @@ export default function Slide(props: SlideProps) {
     verticalPadding,
     backgroundColor,
     backgroundImage,
+    loading,
     enableOverlay,
     overlayOpacity,
     overlayColor,
@@ -83,13 +84,13 @@ export default function Slide(props: SlideProps) {
     children,
     ...rest
   } = props;
-
   return (
     <div {...rest} className="h-full w-full">
       <OverlayAndBackground
         backgroundImage={backgroundImage}
         backgroundFit={backgroundFit}
         backgroundPosition={backgroundPosition}
+        loading={loading}
         enableOverlay={enableOverlay}
         overlayOpacity={overlayOpacity}
         overlayColor={overlayColor}


### PR DESCRIPTION
Section backgrounds render via BackgroundImage, which inherited
Hydrogen Image's loading=lazy default — including the hero/slideshow
backgrounds that are the LCP element on most Weaverse pages. Lighthouse
mobile measured 13.6s LCP on the demo homepage with the LCP image
explicitly flagged for loading=lazy and missing fetchpriority.

- BackgroundImage accepts loading; eager implies fetchPriority=high and
  sizes=100vw (sizes=auto is only valid for lazy images)
- hero-image sections always render their background eagerly
- slideshow marks its first slide eager via cloneElement; remaining
  slides stay lazy
