### PR TITLE
fix: hero-video container squashed by premature height measurement

### DIFF
--- a/app/sections/hero-video/index.tsx
+++ b/app/sections/hero-video/index.tsx
@@ -159,7 +159,6 @@ export default function HeroVideo(props: HeroVideoProps) {
    */
   function handleResize() {
     setSize(getPlayerSize(id));
-
     // First, try intrinsic calculation
     if (containerRef.current && video?.width && video?.height) {
       const containerWidth = containerRef.current.getBoundingClientRect().width;
@@ -168,9 +167,53 @@ export default function HeroVideo(props: HeroVideoProps) {
         setVideoHeight(calculatedHeight);
       }
     }
-
     // Then sync with actual video element after a brief delay
     requestAnimationFrame(syncVideoHeight);
+  }
+  /**
+   * A single post-mount measurement is a race: if it lands before the video
+   * metadata loads, the <video> element reports the browser default 300x150
+   * and the container gets locked at ~150px (intermittent squashed hero).
+   * Watch for the media element (react-player mounts lazily) and keep the
+   * container in sync with a ResizeObserver — metadata load, player chrome,
+   * and breakpoint changes all resize the element and re-trigger the sync.
+   */
+  function watchMediaElement(): (() => void) | undefined {
+    if (!isBrowser || !containerRef.current) {
+      return undefined;
+    }
+    let observer: ResizeObserver | null = null;
+    let pollId: ReturnType<typeof setInterval> | null = null;
+    let attempts = 0;
+    const attach = () => {
+      const mediaEl = containerRef.current?.querySelector("video, iframe");
+      if (!mediaEl) {
+        // Lazy player chunk not mounted yet — retry briefly.
+        attempts += 1;
+        if (attempts > 100 && pollId) {
+          clearInterval(pollId);
+        }
+        return;
+      }
+      if (pollId) {
+        clearInterval(pollId);
+        pollId = null;
+      }
+      syncVideoHeight();
+      observer = new ResizeObserver(() => syncVideoHeight());
+      observer.observe(mediaEl);
+      if (mediaEl instanceof HTMLVideoElement) {
+        mediaEl.addEventListener("loadedmetadata", syncVideoHeight);
+      }
+    };
+    pollId = setInterval(attach, 100);
+    attach();
+    return () => {
+      if (pollId) {
+        clearInterval(pollId);
+      }
+      observer?.disconnect();
+    };
   }
 
   // Reset hideContent when video is paused (show content immediately)
@@ -197,8 +240,10 @@ export default function HeroVideo(props: HeroVideoProps) {
   useEffect(() => {
     handleResize();
     window.addEventListener("resize", handleResize);
+    const stopWatching = inView ? watchMediaElement() : undefined;
     return () => {
       window.removeEventListener("resize", handleResize);
+      stopWatching?.();
     };
   }, [inView, height, heightOnDesktop]);
 


### PR DESCRIPTION
syncVideoHeight ran once via requestAnimationFrame when the section
entered the viewport; if it landed before video metadata loaded, the
<video> element reported the browser default 300x150 and the container
locked at ~150px with no re-measure until a window resize. Intermittent
by timing — faster document delivery (full-page cache) and
high-priority hero images widened the race window.

Replace the one-shot measurement with a ResizeObserver on the media
element (plus loadedmetadata for <video>): metadata load, player
chrome, and breakpoint changes all re-trigger the sync. A short poll
covers react-player's lazy mount; everything detaches on unmount.
