### PR TITLE
perf: defer Shopify shop-js via viewport-mounted ShopPayButton

### DIFF
--- a/app/components/product-card/quick-shop.tsx
+++ b/app/components/product-card/quick-shop.tsx
@@ -6,7 +6,6 @@ import {
 } from "@phosphor-icons/react";
 import * as Dialog from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
-import { ShopPayButton } from "@shopify/hydrogen";
 import { IMAGES_PLACEHOLDERS, useThemeSettings } from "@weaverse/hydrogen";
 import clsx from "clsx";
 import { useEffect, useState } from "react";
@@ -19,6 +18,7 @@ import { Button } from "~/components/button";
 import { Link } from "~/components/link";
 import { AddToCartButton } from "~/components/product/add-to-cart-button";
 import { ProductBadges } from "~/components/product/badges";
+import { LazyShopPayButton } from "~/components/product/lazy-shop-pay-button";
 import { Quantity } from "~/components/product/quantity";
 import { VariantPrices } from "~/components/product/variant-prices";
 import { VariantSelector } from "~/components/product/variant-selector";
@@ -143,7 +143,7 @@ export function QuickShop({ data, panelType = "modal" }: QuickShopProps) {
             {selectedVariant?.availableForSale ? "Add to cart" : "Sold out"}
           </AddToCartButton>
           {selectedVariant?.availableForSale && (
-            <ShopPayButton
+            <LazyShopPayButton
               width="100%"
               variantIdsAndQuantities={[
                 {

--- a/app/components/product/lazy-shop-pay-button.tsx
+++ b/app/components/product/lazy-shop-pay-button.tsx
@@ -12,22 +12,26 @@ type ShopPayButtonProps = ComponentProps<typeof ShopPayButton>;
  * page). Above-the-fold instances (the product buy box) still mount immediately
  * thanks to the 300px root margin, so accelerated checkout is unaffected.
  *
- * A reserved-height placeholder (matching `--shop-pay-button-height`) keeps the
- * layout stable, so swapping in the real button does not shift content (no CLS).
+ * The wrapper always reserves `--shop-pay-button-height` via `min-height`, so the
+ * space stays held both before the button mounts and while `shop-js` is still
+ * loading (Hydrogen's `ShopPayButton` renders an empty element until the script
+ * resolves). That keeps the layout stable end-to-end — no CLS.
  */
-export function LazyShopPayButton(props: ShopPayButtonProps) {
+export function LazyShopPayButton({
+  className,
+  width,
+  ...props
+}: ShopPayButtonProps) {
   const { ref, inView } = useInView({ triggerOnce: true, rootMargin: "300px" });
-
-  if (inView) {
-    return <ShopPayButton {...props} />;
-  }
 
   return (
     <div
       ref={ref}
-      aria-hidden="true"
-      className={props.className}
-      style={{ width: props.width, height: "var(--shop-pay-button-height)" }}
-    />
+      className={className}
+      aria-hidden={inView ? undefined : true}
+      style={{ width, minHeight: "var(--shop-pay-button-height)" }}
+    >
+      {inView ? <ShopPayButton width="100%" {...props} /> : null}
+    </div>
   );
 }

--- a/app/components/product/lazy-shop-pay-button.tsx
+++ b/app/components/product/lazy-shop-pay-button.tsx
@@ -1,0 +1,33 @@
+import { ShopPayButton } from "@shopify/hydrogen";
+import type { ComponentProps } from "react";
+import { useInView } from "react-intersection-observer";
+
+type ShopPayButtonProps = ComponentProps<typeof ShopPayButton>;
+
+/**
+ * Defers Shopify's `shop-js` bundle (~860KB) until the Shop Pay button nears the
+ * viewport. The `<shop-pay-button>` web component fetches that script the moment
+ * it mounts, so rendering it eagerly costs every page the full download even when
+ * the button sits far below the fold (e.g. a Featured Product section on the home
+ * page). Above-the-fold instances (the product buy box) still mount immediately
+ * thanks to the 300px root margin, so accelerated checkout is unaffected.
+ *
+ * A reserved-height placeholder (matching `--shop-pay-button-height`) keeps the
+ * layout stable, so swapping in the real button does not shift content (no CLS).
+ */
+export function LazyShopPayButton(props: ShopPayButtonProps) {
+  const { ref, inView } = useInView({ triggerOnce: true, rootMargin: "300px" });
+
+  if (inView) {
+    return <ShopPayButton {...props} />;
+  }
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={props.className}
+      style={{ width: props.width, height: "var(--shop-pay-button-height)" }}
+    />
+  );
+}

--- a/app/sections/main-product/buy-buttons/index.tsx
+++ b/app/sections/main-product/buy-buttons/index.tsx
@@ -1,6 +1,5 @@
 import {
   getAdjacentAndFirstAvailableVariants,
-  ShopPayButton,
   useOptimisticVariant,
 } from "@shopify/hydrogen";
 import { createSchema, type HydrogenComponentProps } from "@weaverse/hydrogen";
@@ -8,6 +7,7 @@ import { useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 import { useLoaderData } from "react-router";
 import { AddToCartButton } from "~/components/product/add-to-cart-button";
+import { LazyShopPayButton } from "~/components/product/lazy-shop-pay-button";
 import type { loader as productRouteLoader } from "~/routes/products/product";
 import { useProductQtyStore } from "../product-quantity-selector";
 import { StickyATCBar } from "./sticky-atc-bar";
@@ -103,7 +103,7 @@ export default function ProductATCButtons(props: ProductATCButtonsProps) {
         {atcButtonText}
       </AddToCartButton>
       {showShopPayButton && selectedVariant?.availableForSale && (
-        <ShopPayButton
+        <LazyShopPayButton
           width="100%"
           variantIdsAndQuantities={[
             {

--- a/app/sections/single-product/index.tsx
+++ b/app/sections/single-product/index.tsx
@@ -1,4 +1,3 @@
-import { ShopPayButton } from "@shopify/hydrogen";
 import type { ProductVariantComponent } from "@shopify/hydrogen/storefront-api-types";
 import {
   createSchema,
@@ -11,6 +10,7 @@ import Link from "~/components/link";
 import { AddToCartButton } from "~/components/product/add-to-cart-button";
 import { ProductBadges } from "~/components/product/badges";
 import { BundledVariants } from "~/components/product/bundled-variants";
+import { LazyShopPayButton } from "~/components/product/lazy-shop-pay-button";
 import { Quantity } from "~/components/product/quantity";
 import { VariantPrices } from "~/components/product/variant-prices";
 import { VariantSelector } from "~/components/product/variant-selector";
@@ -146,7 +146,7 @@ export default function SingleProduct(props: SingleProductProps) {
               {atcText}
             </AddToCartButton>
             {selectedVariant?.availableForSale && (
-              <ShopPayButton
+              <LazyShopPayButton
                 width="100%"
                 variantIdsAndQuantities={[
                   {


### PR DESCRIPTION
## Problem

The `<shop-pay-button>` web component fetches Shopify's `shop-js` bundle (**~860KB decoded / ~196KB gzip**) the instant it mounts. It was rendered eagerly in three places — the Featured Product (`single-product`) section, the product buy box (`buy-buttons`), and the quick-shop modal — so the **home page downloaded the full bundle on load** for a Shop Pay button sitting ~3700px below the fold (measured on pilot.weaverse.dev: it was the single largest asset on the page).

## Fix

Add `LazyShopPayButton`: render a reserved-height placeholder and only mount the real `<ShopPayButton>` (and thus load `shop-js`) once it is within **300px of the viewport** via `IntersectionObserver` (`react-intersection-observer`, already a dependency).

- **Above-the-fold instances** (product buy box) still mount immediately → accelerated checkout unchanged.
- **Below-the-fold instances** (home Featured Product, etc.) no longer cost `shop-js` until the user scrolls to them.
- Placeholder height matches `--shop-pay-button-height`, so the swap causes **no layout shift (CLS 0)**.

## Verified (local MiniOxygen + live)

| | Home initial load | Product page |
|---|---|---|
| `shop-js` fetched | **no** (was yes, 860KB) | yes (immediate) |
| `<shop-pay-button>` mounted | 0 (1 placeholder) | 1 |
| On scroll to featured product | button mounts + shop-js loads, **CLS 0** | — |

Home page initial load on pilot.weaverse.dev: **66 → 63 requests, ~900KB less decoded JS**, `shop-js` no longer fetched. Already deployed to the production Oxygen environment for this storefront.