### PR TITLE
perf(mobile): fix reveal-gated LCP, responsive images, load-time interstitial

### DIFF
--- a/app/components/root/newsletter-popup.tsx
+++ b/app/components/root/newsletter-popup.tsx
@@ -67,17 +67,38 @@ export function NewsletterPopup() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: just need to run once
   useEffect(() => {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    if (!isDesignMode) {
-      const isDismissed = localStorage.getItem(POPUP_DISMISSED_KEY) === "true";
-      if (isDismissed) {
-        return;
-      }
-      timer = setTimeout(() => {
-        setOpen(true);
-      }, newsletterPopupDelay * 1000);
+    if (isDesignMode) {
+      return;
     }
-    return () => clearTimeout(timer);
+    if (localStorage.getItem(POPUP_DISMISSED_KEY) === "true") {
+      return;
+    }
+    // Defer the popup until the visitor first engages (scroll/pointer/key/
+    // touch), then honor the configured delay. A newsletter popup that covers
+    // the hero during the initial render is an intrusive interstitial: it hurts
+    // perceived load (the popup becomes the last-painted content) and is poor
+    // UX. Gating on first interaction mirrors the GTM defer in
+    // custom-analytics.tsx and only shows the popup to engaged visitors.
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const intentEvents = ["pointerdown", "keydown", "touchstart", "scroll"];
+    function start() {
+      cleanup();
+      timer = setTimeout(() => setOpen(true), newsletterPopupDelay * 1000);
+    }
+    function cleanup() {
+      for (const event of intentEvents) {
+        window.removeEventListener(event, start);
+      }
+    }
+    for (const event of intentEvents) {
+      window.addEventListener(event, start, { once: true, passive: true });
+    }
+    return () => {
+      cleanup();
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+    };
   }, []);
 
   // Re-open popup when settings change in design mode

--- a/app/components/scroll-reveal.tsx
+++ b/app/components/scroll-reveal.tsx
@@ -1,8 +1,15 @@
 import { useThemeSettings } from "@weaverse/hydrogen";
 import { cva } from "class-variance-authority";
-import { useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import type { ThemeSettings } from "~/types/weaverse";
 import { cn } from "~/utils/cn";
+
+/**
+ * When true (via provider), descendant ScrollReveals render visible
+ * immediately. Provided by above-the-fold/LCP containers (e.g. the first
+ * slideshow slide) so hero text is not hidden until hydration runs.
+ */
+export const RevealImmediateContext = createContext(false);
 
 /**
  * Shared IntersectionObserver utility
@@ -123,6 +130,8 @@ export function ScrollReveal({
   ...rest
 }: ScrollRevealProps) {
   let { revealElementsOnScroll } = useThemeSettings<ThemeSettings>();
+  let immediateFromContext = useContext(RevealImmediateContext);
+  let isImmediate = immediate || immediateFromContext;
   let [isVisible, setIsVisible] = useState(false);
   let [revealed, setRevealed] = useState(false);
   let internalRef = useRef<HTMLElement>(null);
@@ -137,7 +146,7 @@ export function ScrollReveal({
   };
 
   useEffect(() => {
-    if (immediate || !revealElementsOnScroll || !internalRef.current) {
+    if (isImmediate || !revealElementsOnScroll || !internalRef.current) {
       return;
     }
 
@@ -148,7 +157,7 @@ export function ScrollReveal({
     });
 
     return cleanup;
-  }, [revealElementsOnScroll, immediate]);
+  }, [revealElementsOnScroll, isImmediate]);
 
   // Strip the reveal transition wrapper from the DOM once the animation
   // finishes so subsequent re-renders don't keep paying for the inline
@@ -169,7 +178,7 @@ export function ScrollReveal({
     return () => el.removeEventListener("transitionend", onEnd);
   }, [isVisible]);
 
-  if (immediate || !revealElementsOnScroll || revealed) {
+  if (isImmediate || !revealElementsOnScroll || revealed) {
     return (
       <Component ref={setRefs} className={className} style={style} {...rest}>
         {children}

--- a/app/components/scroll-reveal.tsx
+++ b/app/components/scroll-reveal.tsx
@@ -100,6 +100,13 @@ interface ScrollRevealProps extends React.HTMLAttributes<HTMLElement> {
   animation?: AnimationType;
   duration?: number;
   delay?: number;
+  /**
+   * Render visible immediately (no opacity-0 reveal gate, no observer).
+   * Required for above-the-fold/LCP sections: the default reveal hides
+   * content until hydration + IntersectionObserver fire, which delays the
+   * LCP element's paint until client JS runs.
+   */
+  immediate?: boolean;
   [key: string]: unknown;
 }
 
@@ -110,6 +117,7 @@ export function ScrollReveal({
   animation = "fade-up",
   duration = 0.5,
   delay = 0,
+  immediate = false,
   className,
   style,
   ...rest
@@ -129,7 +137,7 @@ export function ScrollReveal({
   };
 
   useEffect(() => {
-    if (!revealElementsOnScroll || !internalRef.current) {
+    if (immediate || !revealElementsOnScroll || !internalRef.current) {
       return;
     }
 
@@ -140,7 +148,7 @@ export function ScrollReveal({
     });
 
     return cleanup;
-  }, [revealElementsOnScroll]);
+  }, [revealElementsOnScroll, immediate]);
 
   // Strip the reveal transition wrapper from the DOM once the animation
   // finishes so subsequent re-renders don't keep paying for the inline
@@ -161,7 +169,7 @@ export function ScrollReveal({
     return () => el.removeEventListener("transitionend", onEnd);
   }, [isVisible]);
 
-  if (!revealElementsOnScroll || revealed) {
+  if (immediate || !revealElementsOnScroll || revealed) {
     return (
       <Component ref={setRefs} className={className} style={style} {...rest}>
         {children}

--- a/app/sections/collection-list/collection-card.tsx
+++ b/app/sections/collection-list/collection-card.tsx
@@ -106,9 +106,7 @@ export function CollectionCard({
         {collectionImage ? (
           <Image
             data={collectionImage}
-            width={collectionImage.width || 600}
-            height={collectionImage.height || 400}
-            sizes="(max-width: 32em) 100vw, 45vw"
+            sizes="(min-width: 48em) 45vw, 100vw"
             loading={loading}
             className={clsx(
               "absolute inset-0 z-0",

--- a/app/sections/featured-collections/collection-items.tsx
+++ b/app/sections/featured-collections/collection-items.tsx
@@ -107,9 +107,7 @@ function CollectionItems(props: CollectionItemsData & HydrogenComponentProps) {
             >
               <Image
                 data={collection.image}
-                width={collection.image.width || 600}
-                height={collection.image.height || 400}
-                sizes="(max-width: 32em) 100vw, 45vw"
+                sizes="(min-width: 48em) 33vw, 67vw"
                 className={clsx([
                   "transition-all duration-300",
                   "scale-100 will-change-transform group-hover:scale-[1.05]",

--- a/app/sections/slideshow/index.tsx
+++ b/app/sections/slideshow/index.tsx
@@ -8,7 +8,10 @@ import clsx from "clsx";
 import { createContext } from "react";
 import { Autoplay, EffectFade, Navigation, Pagination } from "swiper/modules";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { ScrollReveal } from "~/components/scroll-reveal";
+import {
+  RevealImmediateContext,
+  ScrollReveal,
+} from "~/components/scroll-reveal";
 import { useWeaverseStudioCheck } from "~/hooks/use-weaverse-studio-check";
 import type { ThemeSettings } from "~/types/weaverse";
 import type { SlideshowArrowsProps } from "./arrows";
@@ -144,7 +147,9 @@ export default function Slideshow(
         {children.map((child, idx) => (
           <SwiperSlide key={idx} className="bg-white">
             <EagerSlideContext.Provider value={idx === 0}>
-              {child}
+              <RevealImmediateContext.Provider value={idx === 0}>
+                {child}
+              </RevealImmediateContext.Provider>
             </EagerSlideContext.Provider>
           </SwiperSlide>
         ))}

--- a/app/sections/slideshow/index.tsx
+++ b/app/sections/slideshow/index.tsx
@@ -98,6 +98,7 @@ export default function Slideshow(
   return (
     <ScrollReveal
       as="section"
+      immediate
       key={Object.values(props)
         .filter((v) => typeof v !== "object")
         .join("-")}


### PR DESCRIPTION
## Mobile performance: fix LCP reveal-gate, responsive images, and load-time interstitial

Four fixes targeting mobile Lighthouse / Core Web Vitals on the storefront. Each addresses a concrete bug, not a micro-tweak. All verified live on `weaverse.dev`.

### Fixes

**1. `1352930a` — Responsive collection images**
`featured-collections/collection-items.tsx` and `collection-list/collection-card.tsx` passed numeric `width={image.width}` / `height={image.height}` to Hydrogen `<Image>`. Numeric `width`/`height` puts Hydrogen `<Image>` into **fixed** mode → it emits a single-candidate density (`1x`) srcset at the source's intrinsic width (1600px) **and strips the `sizes` attribute**. Mobile downloaded a 1600px image into a ~400px slot. Fix: drop the numeric `width`/`height` (keep `data` + `sizes`) so the image is responsive (width-descriptor srcset, `sizes` honored). The aspect-ratio wrapper already reserves layout space → no CLS.
→ Lighthouse "improve image delivery" **865 KiB → 241 KiB**.

**2. `ad823859` — Render hero slideshow immediately (LCP)**
The slideshow section is wrapped in `<ScrollReveal>`, which renders `opacity-0` until **hydration + IntersectionObserver** fire. The LCP element (hero background) was downloaded but invisible until client JS ran. Added an `immediate` prop to `ScrollReveal` (SSR-visible, no observer) and applied it to the hero slideshow.
→ LCP **render delay 1206ms → ~60ms**, LCP **7.4s → 4.5s** (mobile, simulated).

**3. `9a404f9f` — Render hero text immediately (Speed Index)**
`heading`/`subheading`/`paragraph`/`button`/`link` each wrap their content in `<ScrollReveal>` too, so hero copy stayed gated even after fix #2. Added `RevealImmediateContext`; the first hero slide provides it so all reveals inside it render immediately.

**4. `49d1ac2e` — Gate newsletter popup behind first interaction**
The popup opened on a raw `setTimeout`, covering the hero mid-load — an intrusive interstitial (poor UX + Google mobile-SEO penalty). Gated it on first engagement (`pointerdown`/`keydown`/`touchstart`/`scroll`), mirroring the existing GTM defer in `custom-analytics.tsx`. The popup still fires for engaged visitors; it no longer interrupts first paint.

### Impact (mobile Lighthouse, Moto-G / slow-4G / 4× CPU)
- Clean score **~57 → ~66**
- LCP **7.4s → 4.5s**; LCP render delay **1206ms → ~60ms**
- CLS **0.005** (no regression); TBT unaffected
- ~624 KiB of image over-fetch removed from the homepage

Observed (un-throttled) FCP/LCP are **~0.85s** — the page is genuinely fast. The residual headline gap to a higher score is a slow-4G *simulation* artifact dominated by TTFB (uncacheable session-bearing home) and render-blocking Tailwind CSS, plus a Speed-Index quirk from the autoplay hero carousel — none of which are addressed here.

### Verification
- `tsc --noEmit` + Biome clean on all changed files.
- Live-verified on `weaverse.dev`: responsive srcset now width-descriptor (`200w…1200w`, `sizes` honored); hero paints without JS; popup absent from initial render; icons/carousel intact; CLS 0.005.

### Risk
- `ScrollReveal` change is additive (new `immediate` prop + context; default behavior unchanged for all existing callers).
- Popup change alters *when* the popup appears (engagement-gated vs. raw timer) — flag for product review if the raw timer is intentional.
