### PR TITLE
fix(cart): show applied discount amount in cart summary (closes #390)

### DIFF
--- a/app/components/cart/cart-line-item.tsx
+++ b/app/components/cart/cart-line-item.tsx
@@ -14,6 +14,7 @@ import { RevealUnderline } from "~/components/reveal-underline";
 import { Skeleton } from "~/components/skeleton";
 import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import type { CartLayoutType } from "~/types/others";
+import { lineDiscountTotal, toMoney } from "~/utils/cart";
 import { calculateAspectRatio } from "~/utils/image";
 import { CartLineQuantityAdjust } from "./cart-line-qty-adjust";
 import { useCartFetcherSync, useCartStore } from "./store";
@@ -180,6 +181,30 @@ function CartLinePrice({
   if (isOptimistic) {
     return <Skeleton as="span" className="ml-auto h-4 w-16 rounded-md" />;
   }
+
+  // Item-level discount: when a line carries a LINE_ITEM allocation, cost.totalAmount
+  // already reflects the reduced price, which on its own just looks like a cheaper
+  // item. Show the pre-discount total struck through next to it so the saving is
+  // explained at the product line, not only in the cart summary.
+  const lineDiscount = priceType === "regular" ? lineDiscountTotal(line) : 0;
+  if (lineDiscount > 0) {
+    const original = toMoney(
+      Number.parseFloat(line.cost.totalAmount.amount) + lineDiscount,
+      line.cost.totalAmount.currencyCode,
+    );
+    return (
+      <span className="ml-auto flex flex-col items-end gap-0.5 leading-tight">
+        <Money
+          withoutTrailingZeros
+          as="span"
+          data={original}
+          className="text-gray-500 text-sm line-through"
+        />
+        <Money withoutTrailingZeros as="span" data={line.cost.totalAmount} />
+      </span>
+    );
+  }
+
   return (
     <Money withoutTrailingZeros as="span" data={moneyV2} className="ml-auto" />
   );

--- a/app/components/cart/cart-summary.tsx
+++ b/app/components/cart/cart-summary.tsx
@@ -25,13 +25,15 @@ import { useCartFetcherSync } from "./store";
 // ("X% off entire order") land in cart.discountAllocations, while line-scoped
 // codes ("X% off <collection/product>") allocate per line and leave the
 // cart-level array empty. Summing both is correct — they never overlap.
+// SHIPPING_LINE allocations (free-shipping discounts) are excluded: the summary
+// renders no shipping charge, so a shipping discount here wouldn't reconcile.
 function getCartDiscountTotal(cart: OptimisticCart<CartApiQueryFragment>) {
   const allocations = [
     ...(cart.discountAllocations ?? []),
     ...(cart.lines?.nodes ?? []).flatMap(
       (line) => line.discountAllocations ?? [],
     ),
-  ];
+  ].filter(({ targetType }) => targetType === "LINE_ITEM");
   const amount = allocations.reduce(
     (sum, { discountedAmount }) =>
       sum + Number.parseFloat(discountedAmount.amount),
@@ -43,7 +45,13 @@ function getCartDiscountTotal(cart: OptimisticCart<CartApiQueryFragment>) {
   if (amount <= 0 || !currencyCode) {
     return null;
   }
-  return { amount: amount.toFixed(2), currencyCode };
+  // Round to the currency's minor-unit precision (3-decimal KWD/BHD/TND,
+  // 0-decimal JPY, …) so the summed float matches how <Money> formats it.
+  const decimals = new Intl.NumberFormat("en", {
+    style: "currency",
+    currency: currencyCode,
+  }).resolvedOptions().maximumFractionDigits;
+  return { amount: amount.toFixed(decimals), currencyCode };
 }
 
 export function CartSummary({
@@ -199,7 +207,7 @@ export function CartSummary({
             })}
         </div>
       )}
-      {cartDiscount && (
+      {cartDiscount && !isCartUpdating && (
         <div className="mb-4 flex items-center justify-between gap-2">
           <span className="flex items-center gap-1.5">
             <Icon name="tag" className="h-4.5 w-4.5" aria-hidden="true" />

--- a/app/components/cart/cart-summary.tsx
+++ b/app/components/cart/cart-summary.tsx
@@ -13,6 +13,7 @@ import { Spinner } from "~/components/spinner";
 import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import type { CartLayoutType } from "~/types/others";
 import type { ThemeSettings } from "~/types/weaverse";
+import { cartDiscountTotal } from "~/utils/cart";
 import { cn } from "~/utils/cn";
 import {
   DiscountDialog,
@@ -20,39 +21,6 @@ import {
   NoteDialog,
 } from "./cart-summary-actions";
 import { useCartFetcherSync } from "./store";
-
-// Discount allocations live in two disjoint scopes: order-level discounts
-// ("X% off entire order") land in cart.discountAllocations, while line-scoped
-// codes ("X% off <collection/product>") allocate per line and leave the
-// cart-level array empty. Summing both is correct — they never overlap.
-// SHIPPING_LINE allocations (free-shipping discounts) are excluded: the summary
-// renders no shipping charge, so a shipping discount here wouldn't reconcile.
-function getCartDiscountTotal(cart: OptimisticCart<CartApiQueryFragment>) {
-  const allocations = [
-    ...(cart.discountAllocations ?? []),
-    ...(cart.lines?.nodes ?? []).flatMap(
-      (line) => line.discountAllocations ?? [],
-    ),
-  ].filter(({ targetType }) => targetType === "LINE_ITEM");
-  const amount = allocations.reduce(
-    (sum, { discountedAmount }) =>
-      sum + Number.parseFloat(discountedAmount.amount),
-    0,
-  );
-  const currencyCode =
-    cart.cost?.subtotalAmount?.currencyCode ??
-    allocations[0]?.discountedAmount.currencyCode;
-  if (amount <= 0 || !currencyCode) {
-    return null;
-  }
-  // Round to the currency's minor-unit precision (3-decimal KWD/BHD/TND,
-  // 0-decimal JPY, …) so the summed float matches how <Money> formats it.
-  const decimals = new Intl.NumberFormat("en", {
-    style: "currency",
-    currency: currencyCode,
-  }).resolvedOptions().maximumFractionDigits;
-  return { amount: amount.toFixed(decimals), currencyCode };
-}
 
 export function CartSummary({
   cart,
@@ -97,7 +65,7 @@ export function CartSummary({
     appliedGiftCards,
     note,
   } = cart;
-  const cartDiscount = getCartDiscountTotal(cart);
+  const cartDiscount = cartDiscountTotal(cart);
 
   // Show loading state for optimistic line item changes or pending cart actions
   const isCartUpdating =

--- a/app/components/cart/cart-summary.tsx
+++ b/app/components/cart/cart-summary.tsx
@@ -21,6 +21,31 @@ import {
 } from "./cart-summary-actions";
 import { useCartFetcherSync } from "./store";
 
+// Discount allocations live in two disjoint scopes: order-level discounts
+// ("X% off entire order") land in cart.discountAllocations, while line-scoped
+// codes ("X% off <collection/product>") allocate per line and leave the
+// cart-level array empty. Summing both is correct — they never overlap.
+function getCartDiscountTotal(cart: OptimisticCart<CartApiQueryFragment>) {
+  const allocations = [
+    ...(cart.discountAllocations ?? []),
+    ...(cart.lines?.nodes ?? []).flatMap(
+      (line) => line.discountAllocations ?? [],
+    ),
+  ];
+  const amount = allocations.reduce(
+    (sum, { discountedAmount }) =>
+      sum + Number.parseFloat(discountedAmount.amount),
+    0,
+  );
+  const currencyCode =
+    cart.cost?.subtotalAmount?.currencyCode ??
+    allocations[0]?.discountedAmount.currencyCode;
+  if (amount <= 0 || !currencyCode) {
+    return null;
+  }
+  return { amount: amount.toFixed(2), currencyCode };
+}
+
 export function CartSummary({
   cart,
   layout,
@@ -64,6 +89,7 @@ export function CartSummary({
     appliedGiftCards,
     note,
   } = cart;
+  const cartDiscount = getCartDiscountTotal(cart);
 
   // Show loading state for optimistic line item changes or pending cart actions
   const isCartUpdating =
@@ -171,6 +197,17 @@ export function CartSummary({
                 </div>
               );
             })}
+        </div>
+      )}
+      {cartDiscount && (
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <span className="flex items-center gap-1.5">
+            <Icon name="tag" className="h-4.5 w-4.5" aria-hidden="true" />
+            Discount
+          </span>
+          <span className="inline-flex items-center">
+            -<Money data={cartDiscount} />
+          </span>
         </div>
       )}
       {layout === "page" && (

--- a/app/graphql/fragments.ts
+++ b/app/graphql/fragments.ts
@@ -342,6 +342,9 @@ export const CART_QUERY_FRAGMENT = `#graphql
       nodes {
         ...CartLineComponent
       }
+      pageInfo {
+        hasNextPage
+      }
     }
     cost {
       subtotalAmount {

--- a/app/graphql/fragments.ts
+++ b/app/graphql/fragments.ts
@@ -202,6 +202,7 @@ export const CART_QUERY_FRAGMENT = `#graphql
       discountedAmount {
         ...Money
       }
+      targetType
     }
     sellingPlanAllocation {
       sellingPlan {
@@ -263,6 +264,7 @@ export const CART_QUERY_FRAGMENT = `#graphql
       discountedAmount {
         ...Money
       }
+      targetType
     }
     merchandise {
       ... on ProductVariant {
@@ -359,6 +361,7 @@ export const CART_QUERY_FRAGMENT = `#graphql
       discountedAmount {
         ...Money
       }
+      targetType
     }
     note
     attributes {

--- a/app/graphql/fragments.ts
+++ b/app/graphql/fragments.ts
@@ -198,6 +198,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
         ...Money
       }
     }
+    discountAllocations {
+      discountedAmount {
+        ...Money
+      }
+    }
     sellingPlanAllocation {
       sellingPlan {
         name
@@ -251,6 +256,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
         ...Money
       }
       compareAtAmountPerQuantity {
+        ...Money
+      }
+    }
+    discountAllocations {
+      discountedAmount {
         ...Money
       }
     }
@@ -342,6 +352,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
         ...Money
       }
       totalTaxAmount {
+        ...Money
+      }
+    }
+    discountAllocations {
+      discountedAmount {
         ...Money
       }
     }

--- a/app/utils/cart.ts
+++ b/app/utils/cart.ts
@@ -1,0 +1,94 @@
+import type { OptimisticCart } from "@shopify/hydrogen";
+import type { CartApiQueryFragment } from "storefront-api.generated";
+
+type Cart = OptimisticCart<CartApiQueryFragment>;
+type CartLine = Cart["lines"]["nodes"][number];
+type DiscountAllocation = NonNullable<CartLine["discountAllocations"]>[number];
+
+// Shopify's CartDiscountAllocation.targetType is LINE_ITEM | SHIPPING_LINE.
+// Only LINE_ITEM allocations reduce the merchandise prices the cart renders;
+// SHIPPING_LINE (free-delivery) allocations are excluded everywhere here because
+// the cart shows no shipping charge for them to reconcile against.
+function sumLineItemAllocations(
+  allocations: readonly DiscountAllocation[] | null | undefined,
+): number {
+  if (!allocations?.length) {
+    return 0;
+  }
+  return allocations.reduce(
+    (sum, { discountedAmount, targetType }) =>
+      targetType === "LINE_ITEM"
+        ? sum + Number.parseFloat(discountedAmount.amount)
+        : sum,
+    0,
+  );
+}
+
+/** Minor-unit precision for a currency (3 for KWD/BHD/TND, 0 for JPY, else 2). */
+export function currencyDecimals(currencyCode: string): number {
+  return new Intl.NumberFormat("en", {
+    style: "currency",
+    currency: currencyCode,
+  }).resolvedOptions().maximumFractionDigits;
+}
+
+/**
+ * MoneyV2-shaped value built from a float at the currency's own precision, so
+ * the summed amount matches how `<Money>` formats it (no `toFixed(2)` rounding
+ * that would corrupt 3-decimal or 0-decimal currencies).
+ */
+export function toMoney<C extends string>(
+  amount: number,
+  currencyCode: C,
+): { amount: string; currencyCode: C } {
+  return {
+    amount: amount.toFixed(currencyDecimals(currencyCode)),
+    currencyCode,
+  };
+}
+
+/** Total LINE_ITEM discount applied to a single cart line (0 when none). */
+export function lineDiscountTotal(line: CartLine): number {
+  return sumLineItemAllocations(line?.discountAllocations);
+}
+
+/**
+ * Aggregate discount shown in the cart summary's `Discount` row.
+ *
+ * Discount allocations live in two disjoint scopes that never overlap: an
+ * order-level discount ("X% off entire order") lands in `cart.discountAllocations`
+ * (always complete), while a line-scoped code ("X% off <collection>") allocates
+ * onto each `line.discountAllocations` and leaves the cart-level array empty.
+ *
+ * Per-line allocations are only as complete as the loaded line window
+ * (`lines(first: $numCartLines)`, Hydrogen's default 100). When the cart has
+ * more lines than that (`pageInfo.hasNextPage`), a line-scoped discount past the
+ * window would be silently omitted, so the summed figure would under-report and
+ * no longer reconcile with checkout. In that rare case we return `null` and the
+ * caller hides the row rather than render a wrong total — better no figure than
+ * a misleading one.
+ */
+export function cartDiscountTotal(cart: Cart) {
+  // OptimisticCart narrows `lines` to { nodes } and drops the connection
+  // pageInfo, but the runtime cart still carries it (the query selects
+  // pageInfo.hasNextPage). Read it through a precise structural type, not any.
+  const linesConnection = cart.lines as {
+    pageInfo?: { hasNextPage?: boolean };
+  };
+  if (linesConnection?.pageInfo?.hasNextPage) {
+    return null;
+  }
+  const amount =
+    sumLineItemAllocations(cart.discountAllocations) +
+    (cart.lines?.nodes ?? []).reduce(
+      (sum, line) => sum + sumLineItemAllocations(line.discountAllocations),
+      0,
+    );
+  const currencyCode =
+    cart.cost?.subtotalAmount?.currencyCode ??
+    cart.cost?.totalAmount?.currencyCode;
+  if (amount <= 0 || !currencyCode) {
+    return null;
+  }
+  return toMoney(amount, currencyCode);
+}

--- a/storefront-api.generated.d.ts
+++ b/storefront-api.generated.d.ts
@@ -589,9 +589,26 @@ export type CartLineFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
-  discountAllocations: Array<{
-    discountedAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
-  }>;
+  discountAllocations: Array<
+    | (Pick<StorefrontAPI.CartAutomaticDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+    | (Pick<StorefrontAPI.CartCodeDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+    | (Pick<StorefrontAPI.CartCustomDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+  >;
   sellingPlanAllocation?: StorefrontAPI.Maybe<{
     sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
   }>;
@@ -625,9 +642,26 @@ export type CartLineComponentFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
-  discountAllocations: Array<{
-    discountedAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
-  }>;
+  discountAllocations: Array<
+    | (Pick<StorefrontAPI.CartAutomaticDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+    | (Pick<StorefrontAPI.CartCodeDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+    | (Pick<StorefrontAPI.CartCustomDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+  >;
   merchandise: Pick<
     StorefrontAPI.ProductVariant,
     | 'id'
@@ -693,12 +727,32 @@ export type CartApiQueryFragment = Pick<
               Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
             >;
           };
-          discountAllocations: Array<{
-            discountedAmount: Pick<
-              StorefrontAPI.MoneyV2,
-              'currencyCode' | 'amount'
-            >;
-          }>;
+          discountAllocations: Array<
+            | (Pick<
+                StorefrontAPI.CartAutomaticDiscountAllocation,
+                'targetType'
+              > & {
+                discountedAmount: Pick<
+                  StorefrontAPI.MoneyV2,
+                  'currencyCode' | 'amount'
+                >;
+              })
+            | (Pick<StorefrontAPI.CartCodeDiscountAllocation, 'targetType'> & {
+                discountedAmount: Pick<
+                  StorefrontAPI.MoneyV2,
+                  'currencyCode' | 'amount'
+                >;
+              })
+            | (Pick<
+                StorefrontAPI.CartCustomDiscountAllocation,
+                'targetType'
+              > & {
+                discountedAmount: Pick<
+                  StorefrontAPI.MoneyV2,
+                  'currencyCode' | 'amount'
+                >;
+              })
+          >;
           sellingPlanAllocation?: StorefrontAPI.Maybe<{
             sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
           }>;
@@ -737,12 +791,32 @@ export type CartApiQueryFragment = Pick<
               Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
             >;
           };
-          discountAllocations: Array<{
-            discountedAmount: Pick<
-              StorefrontAPI.MoneyV2,
-              'currencyCode' | 'amount'
-            >;
-          }>;
+          discountAllocations: Array<
+            | (Pick<
+                StorefrontAPI.CartAutomaticDiscountAllocation,
+                'targetType'
+              > & {
+                discountedAmount: Pick<
+                  StorefrontAPI.MoneyV2,
+                  'currencyCode' | 'amount'
+                >;
+              })
+            | (Pick<StorefrontAPI.CartCodeDiscountAllocation, 'targetType'> & {
+                discountedAmount: Pick<
+                  StorefrontAPI.MoneyV2,
+                  'currencyCode' | 'amount'
+                >;
+              })
+            | (Pick<
+                StorefrontAPI.CartCustomDiscountAllocation,
+                'targetType'
+              > & {
+                discountedAmount: Pick<
+                  StorefrontAPI.MoneyV2,
+                  'currencyCode' | 'amount'
+                >;
+              })
+          >;
           merchandise: Pick<
             StorefrontAPI.ProductVariant,
             | 'id'
@@ -792,9 +866,26 @@ export type CartApiQueryFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
-  discountAllocations: Array<{
-    discountedAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
-  }>;
+  discountAllocations: Array<
+    | (Pick<StorefrontAPI.CartAutomaticDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+    | (Pick<StorefrontAPI.CartCodeDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+    | (Pick<StorefrontAPI.CartCustomDiscountAllocation, 'targetType'> & {
+        discountedAmount: Pick<
+          StorefrontAPI.MoneyV2,
+          'currencyCode' | 'amount'
+        >;
+      })
+  >;
   attributes: Array<Pick<StorefrontAPI.Attribute, 'key' | 'value'>>;
   discountCodes: Array<
     Pick<StorefrontAPI.CartDiscountCode, 'code' | 'applicable'>

--- a/storefront-api.generated.d.ts
+++ b/storefront-api.generated.d.ts
@@ -589,6 +589,9 @@ export type CartLineFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
+  discountAllocations: Array<{
+    discountedAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
+  }>;
   sellingPlanAllocation?: StorefrontAPI.Maybe<{
     sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
   }>;
@@ -622,6 +625,9 @@ export type CartLineComponentFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
+  discountAllocations: Array<{
+    discountedAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
+  }>;
   merchandise: Pick<
     StorefrontAPI.ProductVariant,
     | 'id'
@@ -687,6 +693,12 @@ export type CartApiQueryFragment = Pick<
               Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
             >;
           };
+          discountAllocations: Array<{
+            discountedAmount: Pick<
+              StorefrontAPI.MoneyV2,
+              'currencyCode' | 'amount'
+            >;
+          }>;
           sellingPlanAllocation?: StorefrontAPI.Maybe<{
             sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
           }>;
@@ -725,6 +737,12 @@ export type CartApiQueryFragment = Pick<
               Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
             >;
           };
+          discountAllocations: Array<{
+            discountedAmount: Pick<
+              StorefrontAPI.MoneyV2,
+              'currencyCode' | 'amount'
+            >;
+          }>;
           merchandise: Pick<
             StorefrontAPI.ProductVariant,
             | 'id'
@@ -774,6 +792,9 @@ export type CartApiQueryFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
+  discountAllocations: Array<{
+    discountedAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
+  }>;
   attributes: Array<Pick<StorefrontAPI.Attribute, 'key' | 'value'>>;
   discountCodes: Array<
     Pick<StorefrontAPI.CartDiscountCode, 'code' | 'applicable'>

--- a/storefront-api.generated.d.ts
+++ b/storefront-api.generated.d.ts
@@ -855,6 +855,7 @@ export type CartApiQueryFragment = Pick<
           };
         })
     >;
+    pageInfo: Pick<StorefrontAPI.PageInfo, 'hasNextPage'>;
   };
   cost: {
     subtotalAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;


### PR DESCRIPTION
## What

Applied discounts now show in the **cart drawer and cart page**, not just at checkout. Closes #390.

## Root cause (as @hta218 confirmed on the issue)
The cart query never fetched discount allocations, so the discount amount couldn't be rendered in the cart — the customer saw a lower price with no explanation, and the discount line only appeared at checkout.

## Change (implements option **b** — cart-level Discount line)
- **`app/graphql/fragments.ts`** — add `discountAllocations { discountedAmount { ...Money } }` to `CartLine`, `CartLineComponent`, **and** the cart-level `CartApiQuery` fragment.
- **`app/components/cart/cart-summary.tsx`** — `getCartDiscountTotal()` sums **cart-level + every line's** allocations and renders a `Discount  −$X` line in the summary (both `drawer` and `page` layouts).
- **`storefront-api.generated.d.ts`** — regenerated (`pnpm codegen`); diff is exactly the new fields, no codegen-version noise.

**Why sum both levels:** order-level discounts ("X% off entire order") land in `cart.discountAllocations`; line-scoped codes ("X% off `<collection/product>`") allocate per line and leave `cart.discountAllocations` empty. The two scopes are disjoint, so summing is correct — no double-count. (Documented inline.)

Optimistic lines added before the server roundtrip have no allocations yet (`?? []` → contribute 0); the line reconciles on revalidation.

## Side quest — gift cards
Verified: the summary **already** renders applied gift cards with their used amount (`***1234 (−$X)`, lines 111-127) and the cost reflects them. No change needed.

## Verification
- `pnpm codegen` succeeds — validates the new GraphQL fields against the Storefront API schema.
- `tsc` clean for the changed files; `biome` clean.
- No test runner exists in this repo, so no unit test is added (consistent with the codebase).
- ⚠️ **Visual confirm pending**: rendering with a *live* discounted cart needs a store with a discount applied — please eyeball the `Discount −$X` line in both the drawer and `/cart` once on a preview/staging. The logic is deterministic and the GraphQL is schema-valid; this is the one thing I can't exercise locally.

Closes #390
