### PR TITLE
feat: add Shopify Inbox chat integration

### DIFF
--- a/.weaverse/docs/shopify-inbox.md
+++ b/.weaverse/docs/shopify-inbox.md
@@ -1,0 +1,92 @@
+# Shopify Inbox (Chat) Integration
+
+Pilot can render the [Shopify Inbox](https://apps.shopify.com/inbox) chat widget on every storefront page, giving shoppers real-time support without leaving the store.
+
+The widget is **opt-in**: it only renders when `PUBLIC_SHOPIFY_INBOX_SHOP_ID` is set, and degrades gracefully (renders nothing) otherwise.
+
+## How it works
+
+- [`app/utils/env.ts`](../../app/utils/env.ts) — `getPublicEnv()` filters the server `Env` down to its `PUBLIC_*` keys so private credentials are never sent to the browser.
+- [`app/root.tsx`](../../app/root.tsx) — the root `loader` returns `publicEnv: getPublicEnv(args.context.env)`, and the `Layout` renders `<ShopifyInbox>` when `publicEnv.PUBLIC_SHOPIFY_INBOX_SHOP_ID` is present.
+- [`app/components/shopify-inbox.tsx`](../../app/components/shopify-inbox.tsx) — loads the chat via Hydrogen's `<Script>` component (async, nonce applied automatically from the CSP provider).
+
+### Global loader — no app-extension UUID required
+
+The component renders the **store-agnostic** loader:
+
+```
+https://cdn.shopify.com/shopifycloud/shopify_chat/storefront/shopifyChatV1.js?...&shop_id=<id>&shop=<domain>
+```
+
+This loader reads `shop_id`/`shop` from its own `<script>` tag and resolves the
+store's widget bundle (`.../storefront/shopifyChatV1Widget.js`) at runtime. It is
+the same tag a Liquid Online Store injects into its `<head>`.
+
+> **Do not** hardcode the theme-app-extension URL
+> (`cdn.shopify.com/extensions/<uuid>/inbox-<version>/assets/shopifyChatV1Widget.js`).
+> That path embeds a store-specific UUID and a pinned version (`inbox-1274`, …)
+> that change per store and per app update. The global loader above has no such
+> dependency.
+
+## Setup
+
+### 1. Enable Shopify Inbox
+
+1. Install the [Shopify Inbox](https://apps.shopify.com/inbox) app in your Shopify admin.
+2. Enable the chat for the **Online Store** sales channel.
+
+### 2. Find your Inbox shop id
+
+1. Open the published Liquid theme preview for your store.
+2. Inspect the `<head>` and find the `shopifyChatV1.js` script tag.
+3. Copy the value of its `shop_id` query parameter.
+
+(See the [reference walkthrough](https://github.com/juanpprieto/hydrogen-chat-inbox?tab=readme-ov-file#1-find-your-shopify-inbox-shop-id) for screenshots.)
+
+### 3. Configure the environment variable
+
+Add the id to `.env`:
+
+```env
+PUBLIC_SHOPIFY_INBOX_SHOP_ID=your-shopify-inbox-shop-id
+```
+
+The chat binds to the domain configured in the Shopify Inbox app (its `data-shop` value). The component sends `PUBLIC_CHECKOUT_DOMAIN` for this — falling back to `PUBLIC_STORE_DOMAIN` — so make sure `PUBLIC_CHECKOUT_DOMAIN` matches the store's primary/checkout domain that Inbox is set up for.
+
+## Configuration options
+
+By default the widget uses a black icon button anchored bottom-right. To customize it, pass a `button` prop to `<ShopifyInbox>` in [`app/root.tsx`](../../app/root.tsx):
+
+```tsx
+<ShopifyInbox
+  shop={{ domain: publicEnv.PUBLIC_CHECKOUT_DOMAIN || publicEnv.PUBLIC_STORE_DOMAIN, id: publicEnv.PUBLIC_SHOPIFY_INBOX_SHOP_ID }}
+  button={{ color: "#000000", style: "icon", position: "bottom_right", verticalPosition: "lowest", text: "chat_with_us", icon: "chat_bubble" }}
+/>
+```
+
+| Option | Default | Values |
+| --- | --- | --- |
+| `color` | `#000000` | Any hex color (e.g. `#202a36`) |
+| `style` | `icon` | `icon`, `text` |
+| `position` | `bottom_right` | `bottom_left`, `bottom_right` |
+| `verticalPosition` | `lowest` | `lowest`, `higher`, `highest` |
+| `text` | `chat_with_us` | `chat_with_us`, `assistance`, `contact`, `help`, `support`, `live_chat`, `message_us`, `need_help`, `no_text` |
+| `icon` | `chat_bubble` | `chat_bubble`, `agent`, `speech_bubble`, `text_message`, `email`, `hand_wave`, `lifebuoy`, `paper_plane`, `service_bell`, `smiley_face`, `question_mark`, `team`, `no_icon` |
+
+## Limitations
+
+- **Localhost:** Shopify's bot protection blocks the widget on `localhost`. The `<script id="shopify-inbox">` tag still renders, but the chat UI will not initialize. Verify on a deployed (staging/production) domain.
+
+## Content Security Policy
+
+No CSP changes are required for the default setup:
+
+- Pilot ships CSP in **report-only** mode (`app/entry.server.tsx`), so violations are logged but never block.
+- The script loads from `cdn.shopify.com`, already allow-listed in `scriptSrc` (`app/weaverse/csp.ts`).
+- The widget's iframe/network calls target `*.shopify.com` / `*.myshopify.com`, already covered by `defaultSrc`/`connectSrc`.
+
+If you switch to an enforcing `Content-Security-Policy` header, keep those Shopify domains allow-listed.
+
+## Security
+
+Only `PUBLIC_*` environment variables reach the client. `getPublicEnv()` strips everything else (e.g. `SESSION_SECRET`, `*_PRIVATE_API_TOKEN`) before the loader serializes data to the browser.

--- a/.weaverse/docs/shopify-inbox.md
+++ b/.weaverse/docs/shopify-inbox.md
@@ -51,7 +51,7 @@ Add the id to `.env`:
 PUBLIC_SHOPIFY_INBOX_SHOP_ID=your-shopify-inbox-shop-id
 ```
 
-The chat binds to the domain configured in the Shopify Inbox app (its `data-shop` value). The component sends `PUBLIC_CHECKOUT_DOMAIN` for this — falling back to `PUBLIC_STORE_DOMAIN` — so make sure `PUBLIC_CHECKOUT_DOMAIN` matches the store's primary/checkout domain that Inbox is set up for.
+`shop.domain` is sent as the Inbox `shop` parameter and uses `PUBLIC_STORE_DOMAIN` (your store's `*.myshopify.com` domain) — the same value Shopify's injected Inbox tag carries — so no additional variable is required.
 
 ## Configuration options
 
@@ -59,7 +59,7 @@ By default the widget uses a black icon button anchored bottom-right. To customi
 
 ```tsx
 <ShopifyInbox
-  shop={{ domain: publicEnv.PUBLIC_CHECKOUT_DOMAIN || publicEnv.PUBLIC_STORE_DOMAIN, id: publicEnv.PUBLIC_SHOPIFY_INBOX_SHOP_ID }}
+  shop={{ domain: publicEnv.PUBLIC_STORE_DOMAIN, id: publicEnv.PUBLIC_SHOPIFY_INBOX_SHOP_ID }}
   button={{ color: "#000000", style: "icon", position: "bottom_right", verticalPosition: "lowest", text: "chat_with_us", icon: "chat_bubble" }}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Pilot supports AI coding agents (Cursor, Claude Code, Windsurf, Codex, GitHub Co
 - [Swiper](https://swiperjs.com/) for carousels/sliders
 - [Judge.me](https://judge.me/) reviews integration
 - [Klaviyo](https://www.klaviyo.com/) integration for email marketing
+- [Shopify Inbox](https://apps.shopify.com/inbox) chat integration ([setup guide](.weaverse/docs/shopify-inbox.md))
 - Full-featured setup of components and routes
 - Fully customizable inside [Weaverse Studio](https://weaverse.io)
 

--- a/app/components/shopify-inbox.tsx
+++ b/app/components/shopify-inbox.tsx
@@ -1,0 +1,104 @@
+import { Script } from "@shopify/hydrogen";
+
+type ShopifyInboxButton = {
+  /** Button color as a hex value, e.g. `#000000`. */
+  color?: string;
+  style?: "icon" | "text";
+  position?: "bottom_left" | "bottom_right";
+  verticalPosition?: "lowest" | "higher" | "highest";
+  text?:
+    | "chat_with_us"
+    | "assistance"
+    | "contact"
+    | "help"
+    | "support"
+    | "live_chat"
+    | "message_us"
+    | "need_help"
+    | "no_text";
+  icon?:
+    | "chat_bubble"
+    | "agent"
+    | "speech_bubble"
+    | "text_message"
+    | "email"
+    | "hand_wave"
+    | "lifebuoy"
+    | "paper_plane"
+    | "service_bell"
+    | "smiley_face"
+    | "question_mark"
+    | "team"
+    | "no_icon";
+};
+
+type ShopifyInboxProps = {
+  /** Store myshopify domain and the Inbox shop id from the app settings. */
+  shop: { domain: string; id: string };
+  /** Chat button appearance. Falls back to `DEFAULT_BUTTON` when omitted. */
+  button?: ShopifyInboxButton;
+  env?: "production" | "development";
+  version?: "V1";
+};
+
+const DEFAULT_BUTTON: Required<ShopifyInboxButton> = {
+  color: "#000000",
+  style: "icon",
+  position: "bottom_right",
+  verticalPosition: "lowest",
+  text: "chat_with_us",
+  icon: "chat_bubble",
+};
+
+// Shopify's chat loader reads abbreviated query-param keys.
+const BUTTON_PARAM_KEYS: Record<keyof ShopifyInboxButton, string> = {
+  color: "c",
+  style: "s",
+  position: "p",
+  verticalPosition: "vp",
+  text: "t",
+  icon: "i",
+};
+
+// Global, store-agnostic loader. It reads `shop_id`/`shop` from its own
+// `<script>` tag and resolves the store's widget bundle at runtime, so no
+// app-extension UUID/version needs to be hardcoded.
+const LOADER_BASE_URL =
+  "https://cdn.shopify.com/shopifycloud/shopify_chat/storefront";
+
+/**
+ * Loads the Shopify Inbox (Shopify Chat) widget via the global loader script.
+ * Renders nothing unless a shop domain and id are provided, so it degrades
+ * gracefully when the store has not configured `PUBLIC_SHOPIFY_INBOX_SHOP_ID`.
+ *
+ * Note: the widget is blocked by Shopify's bot protection on localhost — verify
+ * on a deployed (staging/production) domain.
+ */
+export function ShopifyInbox({
+  shop,
+  button,
+  env = "production",
+  version = "V1",
+}: ShopifyInboxProps) {
+  if (!(shop?.domain && shop?.id)) {
+    console.error(
+      "ShopifyInbox: `shop.domain` and `shop.id` are required. Find them in the Shopify Inbox app settings.",
+    );
+    return null;
+  }
+
+  const mergedButton = { ...DEFAULT_BUTTON, ...button };
+  const params = new URLSearchParams({
+    v: version.replace(/^V/i, ""),
+    api_env: env,
+    shop_id: shop.id,
+    shop: shop.domain,
+  });
+  for (const [key, paramKey] of Object.entries(BUTTON_PARAM_KEYS)) {
+    params.set(paramKey, mergedButton[key as keyof ShopifyInboxButton]);
+  }
+
+  const src = `${LOADER_BASE_URL}/shopifyChat${version}.js?${params}`;
+
+  return <Script async id="shopify-inbox" src={src} suppressHydrationWarning />;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -218,9 +218,7 @@ export const Layout = withWeaverse(function RootLayout({
         {publicEnv?.PUBLIC_SHOPIFY_INBOX_SHOP_ID && (
           <ShopifyInbox
             shop={{
-              domain:
-                publicEnv.PUBLIC_CHECKOUT_DOMAIN ||
-                publicEnv.PUBLIC_STORE_DOMAIN,
+              domain: publicEnv.PUBLIC_STORE_DOMAIN,
               id: publicEnv.PUBLIC_SHOPIFY_INBOX_SHOP_ID,
             }}
           />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -32,8 +32,10 @@ import {
   useShouldRenderNewsletterPopup,
 } from "./components/root/newsletter-popup";
 import { NotFound } from "./components/root/not-found";
+import { ShopifyInbox } from "./components/shopify-inbox";
 import styles from "./styles/app.css?url";
 import { DEFAULT_LOCALE } from "./utils/const";
+import { getPublicEnv } from "./utils/env";
 import { GlobalStyle } from "./weaverse/style";
 
 export type RootLoader = typeof loader;
@@ -66,6 +68,7 @@ export async function loader(args: LoaderFunctionArgs) {
   return {
     ...deferredData,
     ...criticalData,
+    publicEnv: getPublicEnv(args.context.env),
   };
 }
 
@@ -108,6 +111,7 @@ export const Layout = withWeaverse(function RootLayout({
   const location = useLocation();
   const nonce = useNonce();
   const data = useRouteLoaderData<RootLoader>("root");
+  const publicEnv = data?.publicEnv;
   const locale = data?.selectedLocale ?? DEFAULT_LOCALE;
   const { topbarHeight, topbarText } = useThemeSettings<ThemeSettings>();
   const shouldShowNewsletterPopup = useShouldRenderNewsletterPopup();
@@ -211,6 +215,16 @@ export const Layout = withWeaverse(function RootLayout({
         <GlobalLoading />
         <ScrollRestoration nonce={nonce} />
         <Scripts nonce={nonce} />
+        {publicEnv?.PUBLIC_SHOPIFY_INBOX_SHOP_ID && (
+          <ShopifyInbox
+            shop={{
+              domain:
+                publicEnv.PUBLIC_CHECKOUT_DOMAIN ||
+                publicEnv.PUBLIC_STORE_DOMAIN,
+              id: publicEnv.PUBLIC_SHOPIFY_INBOX_SHOP_ID,
+            }}
+          />
+        )}
       </body>
     </html>
   );

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -1,0 +1,19 @@
+/**
+ * `Env` narrowed to the variables that are safe to expose to the browser.
+ * Only keys prefixed with `PUBLIC_` are kept, mirroring Shopify/Oxygen's
+ * convention for client-safe configuration.
+ */
+export type PublicEnv = {
+  [K in keyof Env as K extends `PUBLIC_${string}` ? K : never]: Env[K];
+};
+
+/**
+ * Filters the server `Env` down to its `PUBLIC_*` entries so the root loader can
+ * forward configuration to the client without leaking private credentials.
+ */
+export function getPublicEnv(env: Env): PublicEnv {
+  const publicEntries = Object.entries(env).filter(([key]) =>
+    key.startsWith("PUBLIC_"),
+  );
+  return Object.fromEntries(publicEntries) as PublicEnv;
+}


### PR DESCRIPTION
Implements Shopify Inbox (Shopify Chat) for the Pilot theme. Closes #338.

## What this does
Renders the Shopify Inbox floating chat button on every page via Shopify's **global** storefront loader (`shopifyChatV1.js`), gated on `PUBLIC_SHOPIFY_INBOX_SHOP_ID` so it no-ops when the store hasn't configured Inbox.

## Changes
- **`app/utils/env.ts`** — `getPublicEnv(env)` forwards only `PUBLIC_*` keys to the client; `PublicEnv` is a mapped type derived from `Env`, so it stays in sync automatically.
- **`app/components/shopify-inbox.tsx`** — `<ShopifyInbox>` loads the widget through Hydrogen's `<Script>` (async, CSP nonce applied automatically). Returns `null` + `console.error` when `shop.domain`/`shop.id` are missing (graceful degradation). Button appearance (color/style/position/text/icon) is configurable, with defaults matching Shopify's.
- **`app/root.tsx`** — root loader returns `publicEnv: getPublicEnv(context.env)`; `Layout` mounts `<ShopifyInbox>` after `<Scripts>` when the shop id is present. `shop.domain` uses `PUBLIC_STORE_DOMAIN` (the store's `*.myshopify.com` domain).
- **Docs** — `.weaverse/docs/shopify-inbox.md` setup guide (find the shop id, config options, localhost caveat) + README bullet.

## Notes
- **Global loader, not the app-extension UUID URL.** `…/storefront/shopifyChatV1.js` reads `shop_id`/`shop` from its own `<script>` tag and resolves the store's widget bundle at runtime, so no per-store/per-app-update UUID is pinned in the theme.
- **`shop` = `PUBLIC_STORE_DOMAIN`.** The widget resolves from the opaque `shop_id`; `shop` is the stable myshopify domain, matching the reference impl, the issue's acceptance snippet, and Shopify's own injected Inbox tag. (Addressed the Codex review — an earlier draft used `PUBLIC_CHECKOUT_DOMAIN`, a custom host that may not match the Inbox key.)
- **Button params match the live tag**: `position: bottom_left|bottom_right` (key `p`), `v=1`, default color `#000000`.
- **No `useEnv()`/`useMatches()` hook** — Pilot reads loader data via `useRouteLoaderData<RootLoader>("root")`; `getPublicEnv` is implemented as specified.
- **No CSP change needed** — `cdn.shopify.com` is already in `script-src`, `*.shopify.com` in `default-src`/`connect-src`.

## Verification
- `npx biome check` + `npx tsc --noEmit` clean.
- Confirmed the button renders on a deployed domain; the heavy `shopifyChatV1Widget.js` lazy-loads on click — expected.
- Localhost caveat documented: Shopify bot protection blocks the widget on `localhost`; verify on a deployed domain.

## Config
Set in the deployment env (already templated in `.env.example`):
```
PUBLIC_SHOPIFY_INBOX_SHOP_ID=<your inbox shop id>
```
