### PR TITLE
fix(inbox): render chat button by injecting loader after window load

### DIFF
--- a/.weaverse/docs/shopify-inbox.md
+++ b/.weaverse/docs/shopify-inbox.md
@@ -8,11 +8,11 @@ The widget is **opt-in**: it only renders when `PUBLIC_SHOPIFY_INBOX_SHOP_ID` is
 
 - [`app/utils/env.ts`](../../app/utils/env.ts) — `getPublicEnv()` filters the server `Env` down to its `PUBLIC_*` keys so private credentials are never sent to the browser.
 - [`app/root.tsx`](../../app/root.tsx) — the root `loader` returns `publicEnv: getPublicEnv(args.context.env)`, and the `Layout` renders `<ShopifyInbox>` when `publicEnv.PUBLIC_SHOPIFY_INBOX_SHOP_ID` is present.
-- [`app/components/shopify-inbox.tsx`](../../app/components/shopify-inbox.tsx) — loads the chat via Hydrogen's `<Script>` component (async, nonce applied automatically from the CSP provider).
+- [`app/components/shopify-inbox.tsx`](../../app/components/shopify-inbox.tsx) — injects the loader `<script>` on the client **after the window `load` event** (see [Why the loader is injected after `load`](#why-the-loader-is-injected-after-load)). The script loads from `cdn.shopify.com`, which the CSP already allow-lists by host, so no nonce is required.
 
 ### Global loader — no app-extension UUID required
 
-The component renders the **store-agnostic** loader:
+The component injects the **store-agnostic** loader:
 
 ```
 https://cdn.shopify.com/shopifycloud/shopify_chat/storefront/shopifyChatV1.js?...&shop_id=<id>&shop=<domain>
@@ -27,6 +27,27 @@ the same tag a Liquid Online Store injects into its `<head>`.
 > That path embeds a store-specific UUID and a pinned version (`inbox-1274`, …)
 > that change per store and per app update. The global loader above has no such
 > dependency.
+
+### Why the loader is injected after `load`
+
+Shopify's loader bootstraps with `window.onload = handler; window.onload()` — it
+**overwrites** `window.onload` and invokes it once immediately. The handler
+mounts an `about:blank` bubble iframe and writes the chat button into it.
+
+If the loader runs **before** the page's real `load` event (e.g. as an SSR
+`<script async>` or any script that executes during initial load), the browser
+fires that reassigned `window.onload` a **second** time on real `load`. The
+second invocation re-mounts the bubble iframe, which resets its document and
+**wipes the freshly written button** — leaving an empty `#shopify-chat-dummy`
+and no visible chat bubble.
+
+Injecting the loader only after `load` (when `document.readyState === "complete"`,
+otherwise on the one-shot `load` listener) keeps `window.onload` to a single
+invocation, so the button renders and persists.
+
+> **Do not** revert this to an SSR `<Script async>` / `defer` tag, or to
+> `waitForHydration` — hydration can finish before `load` on image-heavy pages,
+> which re-introduces the double-invocation and the empty button.
 
 ## Setup
 
@@ -75,7 +96,7 @@ By default the widget uses a black icon button anchored bottom-right. To customi
 
 ## Limitations
 
-- **Localhost:** Shopify's bot protection blocks the widget on `localhost`. The `<script id="shopify-inbox">` tag still renders, but the chat UI will not initialize. Verify on a deployed (staging/production) domain.
+- **Localhost:** Shopify's bot protection blocks the widget on `localhost`. The loader `<script>` is still injected (after `load`), but the chat UI will not initialize. Verify on a deployed (staging/production) domain.
 
 ## Content Security Policy
 

--- a/app/components/shopify-inbox.tsx
+++ b/app/components/shopify-inbox.tsx
@@ -1,4 +1,4 @@
-import { Script } from "@shopify/hydrogen";
+import { useEffect } from "react";
 
 type ShopifyInboxButton = {
   /** Button color as a hex value, e.g. `#000000`. */
@@ -66,10 +66,20 @@ const BUTTON_PARAM_KEYS: Record<keyof ShopifyInboxButton, string> = {
 const LOADER_BASE_URL =
   "https://cdn.shopify.com/shopifycloud/shopify_chat/storefront";
 
+const SCRIPT_ID = "shopify-inbox";
+
 /**
  * Loads the Shopify Inbox (Shopify Chat) widget via the global loader script.
  * Renders nothing unless a shop domain and id are provided, so it degrades
  * gracefully when the store has not configured `PUBLIC_SHOPIFY_INBOX_SHOP_ID`.
+ *
+ * The loader is injected on the client only after the window `load` event.
+ * Shopify's script assigns `window.onload` and immediately self-invokes it; if
+ * it runs before the page finishes loading, the browser fires that handler a
+ * second time on the real `load` event, which re-mounts the chat iframe and
+ * wipes the freshly rendered button (leaving an empty `#shopify-chat-dummy`,
+ * i.e. no visible bubble). Deferring injection until after `load` keeps the
+ * handler to a single invocation so the button persists.
  *
  * Note: the widget is blocked by Shopify's bot protection on localhost — verify
  * on a deployed (staging/production) domain.
@@ -80,25 +90,49 @@ export function ShopifyInbox({
   env = "production",
   version = "V1",
 }: ShopifyInboxProps) {
-  if (!(shop?.domain && shop?.id)) {
-    console.error(
-      "ShopifyInbox: `shop.domain` and `shop.id` are required. Find them in the Shopify Inbox app settings.",
-    );
-    return null;
+  const isConfigured = Boolean(shop?.domain && shop?.id);
+
+  let src = "";
+  if (isConfigured) {
+    const mergedButton = { ...DEFAULT_BUTTON, ...button };
+    const params = new URLSearchParams({
+      v: version.replace(/^V/i, ""),
+      api_env: env,
+      shop_id: shop.id,
+      shop: shop.domain,
+    });
+    for (const [key, paramKey] of Object.entries(BUTTON_PARAM_KEYS)) {
+      params.set(paramKey, mergedButton[key as keyof ShopifyInboxButton]);
+    }
+    src = `${LOADER_BASE_URL}/shopifyChat${version}.js?${params}`;
   }
 
-  const mergedButton = { ...DEFAULT_BUTTON, ...button };
-  const params = new URLSearchParams({
-    v: version.replace(/^V/i, ""),
-    api_env: env,
-    shop_id: shop.id,
-    shop: shop.domain,
-  });
-  for (const [key, paramKey] of Object.entries(BUTTON_PARAM_KEYS)) {
-    params.set(paramKey, mergedButton[key as keyof ShopifyInboxButton]);
-  }
+  useEffect(() => {
+    if (!src) {
+      console.error(
+        "ShopifyInbox: `shop.domain` and `shop.id` are required. Find them in the Shopify Inbox app settings.",
+      );
+      return;
+    }
 
-  const src = `${LOADER_BASE_URL}/shopifyChat${version}.js?${params}`;
+    function injectLoader() {
+      if (document.getElementById(SCRIPT_ID)) {
+        return;
+      }
+      const script = document.createElement("script");
+      script.id = SCRIPT_ID;
+      script.async = true;
+      script.src = src;
+      document.head.appendChild(script);
+    }
 
-  return <Script async id="shopify-inbox" src={src} suppressHydrationWarning />;
+    if (document.readyState === "complete") {
+      injectLoader();
+      return;
+    }
+    window.addEventListener("load", injectLoader, { once: true });
+    return () => window.removeEventListener("load", injectLoader);
+  }, [src]);
+
+  return null;
 }


### PR DESCRIPTION
## Problem

The Shopify Inbox chat bubble never rendered on the storefront — on **every** page, in fresh browser sessions, on both `pilot.weaverse.dev` and `weaverse.dev`. The loader `<script>` ran and created the bubble iframe, but the iframe body stayed `<div id="shopify-chat-dummy"></div>` (empty) — no button, nothing visible to click.

## Root cause

Verified by re-running the *identical* loader URL at two different times on a live page:

| When the loader runs | Result |
| --- | --- |
| During initial page load (SSR `<Script async>`) | `#shopify-chat-dummy` empty — **no button** |
| After the page settled (re-injected) | `<button id="dummy-chat-button" …>` — **button renders** |

Shopify's loader bootstraps with `window.onload = handler; window.onload()` — it **overwrites** `window.onload` and self-invokes it once. As an SSR `<Script async>` the loader executed *before* the page's real `load` event, so the browser fired that reassigned handler a **second** time on real `load`. The second invocation re-mounted the `about:blank` bubble iframe, reset its document, and wiped the freshly written button.

Not a store/config issue: the live loader URL already carried the full appearance config (`…&t=chat_with_us&i=chat_bubble&c=%23000000&s=icon&p=bottom_right&vp=lowest`), and there were **zero** JS errors and **zero** CSP violations.

## Fix

Inject the loader on the client only **after** `load`:
- run immediately when `document.readyState === "complete"`,
- otherwise attach a one-shot `window` `load` listener.

`window.onload` then fires exactly once → the button renders and persists. The component now returns `null` and injects via effect (no SSR `<script>`), so there is no during-load execution. The script loads from `cdn.shopify.com` (already host-allow-listed in the CSP), so dropping the nonce-bearing `<Script>` wrapper is safe.

## Verification

- `npx biome check` ✓
- `npx tsc --noEmit` ✓
- `npm run build` ✓ (SSR + client)
- Browser: confirmed the identical loader renders the button when run after `load` (the fix's condition); zero errors / CSP violations.

> Final confirmation requires a deploy — the widget is blocked by Shopify bot protection on `localhost`, so the rendered bubble can only be verified on a deployed domain. After this merges and the demo fork syncs, re-probe `pilot.weaverse.dev`.

## Notes

Do **not** revert to `<Script async>` / `defer` / `waitForHydration` — hydration can finish before `load` on image-heavy pages, re-introducing the double-invoke. Rationale is documented in `.weaverse/docs/shopify-inbox.md`.