### PR TITLE
feat(sections): add Contact us section with a Message us chat button

### DIFF
--- a/app/components/shopify-inbox.tsx
+++ b/app/components/shopify-inbox.tsx
@@ -68,6 +68,12 @@ const LOADER_BASE_URL =
 
 const SCRIPT_ID = "shopify-inbox";
 
+// Shopify renders the chat bubble as a `<button>` inside a same-origin
+// `about:blank` iframe. These ids are Shopify-internal (undocumented) and could
+// change if Shopify updates the chat loader.
+const BUBBLE_IFRAME_ID = "dummy-chat-button-iframe";
+const BUBBLE_BUTTON_ID = "dummy-chat-button";
+
 /**
  * Loads the Shopify Inbox (Shopify Chat) widget via the global loader script.
  * Renders nothing unless a shop domain and id are provided, so it degrades
@@ -135,4 +141,29 @@ export function ShopifyInbox({
   }, [src]);
 
   return null;
+}
+
+/**
+ * Opens (toggles) the Shopify Inbox chat by clicking its bubble button. Returns
+ * `true` when the button exists and was clicked, `false` otherwise (e.g. the
+ * loader has not rendered the button yet, or Inbox is not configured).
+ *
+ * There is no supported Shopify API to send or pre-fill a message from the
+ * storefront — the chat composer runs in a Shopify-hosted, cross-origin context
+ * — so opening the widget is the only durable programmatic action.
+ */
+export function openShopifyInbox(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+  const iframe = document.getElementById(
+    BUBBLE_IFRAME_ID,
+  ) as HTMLIFrameElement | null;
+  const button =
+    iframe?.contentWindow?.document?.getElementById(BUBBLE_BUTTON_ID);
+  if (button) {
+    button.click();
+    return true;
+  }
+  return false;
 }

--- a/app/sections/contact-us/index.tsx
+++ b/app/sections/contact-us/index.tsx
@@ -1,0 +1,32 @@
+import { createSchema } from "@weaverse/hydrogen";
+import type { SectionProps } from "~/components/section";
+import { Section, sectionSettings } from "~/components/section";
+
+interface ContactUsProps extends SectionProps {}
+
+function ContactUs(props: ContactUsProps) {
+  const { children, ...rest } = props;
+  return <Section {...rest}>{children}</Section>;
+}
+
+export default ContactUs;
+
+export const schema = createSchema({
+  type: "contact-us",
+  title: "Contact us",
+  settings: sectionSettings,
+  childTypes: ["subheading", "heading", "paragraph", "message-us-button"],
+  presets: {
+    gap: 20,
+    children: [
+      { type: "subheading", content: "Support" },
+      { type: "heading", content: "Need help?" },
+      {
+        type: "paragraph",
+        content:
+          "Chat with our team and we'll get back to you as soon as possible.",
+      },
+      { type: "message-us-button" },
+    ],
+  },
+});

--- a/app/sections/contact-us/message-us-button.tsx
+++ b/app/sections/contact-us/message-us-button.tsx
@@ -1,0 +1,54 @@
+import { createSchema, type HydrogenComponentProps } from "@weaverse/hydrogen";
+import { Button } from "~/components/button";
+import { openShopifyInbox } from "~/components/shopify-inbox";
+
+interface MessageUsButtonProps extends HydrogenComponentProps {
+  buttonText: string;
+  variant: "primary" | "secondary" | "outline" | "underline";
+}
+
+function MessageUsButton(props: MessageUsButtonProps) {
+  const { buttonText, variant, ...rest } = props;
+  return (
+    <div {...rest}>
+      <Button onClick={openShopifyInbox} variant={variant}>
+        {buttonText}
+      </Button>
+    </div>
+  );
+}
+
+export default MessageUsButton;
+
+export const schema = createSchema({
+  type: "message-us-button",
+  title: "Message us button",
+  settings: [
+    {
+      group: "Button",
+      inputs: [
+        {
+          type: "text",
+          name: "buttonText",
+          label: "Button text",
+          defaultValue: "Message us",
+          placeholder: "Message us",
+        },
+        {
+          type: "select",
+          name: "variant",
+          label: "Variant",
+          configs: {
+            options: [
+              { value: "primary", label: "Primary" },
+              { value: "secondary", label: "Secondary" },
+              { value: "outline", label: "Outline" },
+              { value: "underline", label: "Underline" },
+            ],
+          },
+          defaultValue: "primary",
+        },
+      ],
+    },
+  ],
+});

--- a/app/weaverse/components.ts
+++ b/app/weaverse/components.ts
@@ -13,6 +13,8 @@ import * as CollectionListItems from "~/sections/collection-list/collections-ite
 import * as ColumnsWithImages from "~/sections/columns-with-images";
 import * as ColumnWithImageItem from "~/sections/columns-with-images/column";
 import * as ColumnsWithImagesItems from "~/sections/columns-with-images/items";
+import * as ContactUs from "~/sections/contact-us";
+import * as MessageUsButton from "~/sections/contact-us/message-us-button";
 import * as Countdown from "~/sections/countdown";
 import * as CountDownTimer from "~/sections/countdown/timer";
 import * as FeaturedCollections from "~/sections/featured-collections";
@@ -115,6 +117,8 @@ export const components: HydrogenComponent[] = [
   CountDownTimer,
   NewsLetter,
   NewsLetterForm,
+  ContactUs,
+  MessageUsButton,
   Blogs,
   BlogPost,
   FeaturedProducts,


### PR DESCRIPTION
Builds on #435 — the chat bubble must actually render for this to be usable.

## What

A new compositional Weaverse section, **Contact us**, that invites shoppers to start a live chat (the existing setup is untouched — these are brand-new files):

- **`contact-us`** — a thin `Section` container (mirrors `newsletter`) with `subheading` + `heading` + `paragraph` + `message-us-button` children and a sensible preset.
- **`message-us-button`** — a child component rendering a `<Button>` that calls `openShopifyInbox()` on click (text + variant configurable).
- **`openShopifyInbox()`** — added next to `ShopifyInbox`; clicks the loader's same-origin bubble button (`#dummy-chat-button` inside `#dummy-chat-button-iframe`) to toggle the chat.

Both are registered in `app/weaverse/components.ts`.

## Why open-only (no send / prefill)

I verified there is **no supported way to `sendMessage(content)` or prefill** the chat from the storefront:

- The widget exposes only `window.Pusher` (transport) + `window.reattachChatWidget` (re-mount) — **no send API**.
- The actual send is an internal `postMessage({text, senderId, userToken, …}, conversationId)` bound to a `conversationId`/`userToken` the widget mints after its own bot/identity checks — not synthesizable from page JS.
- The composer runs in a Shopify-hosted, cross-origin context (no same-origin composer reachable).
- A `draftMessage` localStorage prefill exists but is undocumented, prefill-only, and fragile — intentionally not used.

So `openShopifyInbox()` (open the chat) is the only durable primitive, and the section is a "Message us" CTA.

## Verification

- `npx biome check` ✓
- `npx tsc --noEmit` ✓
- `npm run build` ✓
- Browser: confirmed clicking `#dummy-chat-button` toggles the widget (loads `window.Pusher`).

> The rendered button only exists after #435 (the load-timing fix). Final end-to-end check — add the section in Studio and click it on a deployed page — once #435 deploys.