### PR TITLE
fix(inbox): open the loaded chat web component, not just the bubble

### DIFF
--- a/.weaverse/docs/shopify-inbox.md
+++ b/.weaverse/docs/shopify-inbox.md
@@ -108,7 +108,7 @@ import { openShopifyInbox } from "~/components/shopify-inbox";
 </button>;
 ```
 
-`openShopifyInbox()` clicks Shopify's bubble button (`#dummy-chat-button`, inside the same-origin `#dummy-chat-button-iframe`) and returns `true` when the button existed and was clicked, `false` otherwise (the loader has not rendered the button yet, or Inbox is not configured). Those element ids are **Shopify-internal and undocumented** — they can change when Shopify updates the chat loader.
+`openShopifyInbox()` opens the widget whatever state it is in: it clicks the loader's placeholder bubble (`#dummy-chat-button`, inside the same-origin `#dummy-chat-button-iframe`) for first-time visitors, or the `[data-spec="toggle-button"]` launcher inside the `<inbox-online-store-chat>` web component's shadow root once the full widget has loaded (skipping the click when the chat is already open, since that launcher toggles). It returns `true` when a launcher was found and clicked or the chat is already open, `false` otherwise (the widget has not rendered yet, or Inbox is not configured). These selectors are **Shopify-internal and undocumented** — they can change when Shopify updates the chat widget.
 
 ## Limitations
 

--- a/app/components/shopify-inbox.tsx
+++ b/app/components/shopify-inbox.tsx
@@ -68,11 +68,15 @@ const LOADER_BASE_URL =
 
 const SCRIPT_ID = "shopify-inbox";
 
-// Shopify renders the chat bubble as a `<button>` inside a same-origin
-// `about:blank` iframe. These ids are Shopify-internal (undocumented) and could
-// change if Shopify updates the chat loader.
+// Shopify-internal (undocumented) selectors for the chat launcher; they could
+// change if Shopify updates the chat widget. Before the widget bundle loads the
+// launcher is a `<button>` inside a same-origin `about:blank` iframe; once it
+// loads the launcher is a `[data-spec="toggle-button"]` in the open shadow root
+// of the `<inbox-online-store-chat>` web component.
 const BUBBLE_IFRAME_ID = "dummy-chat-button-iframe";
 const BUBBLE_BUTTON_ID = "dummy-chat-button";
+const WIDGET_TAG = "inbox-online-store-chat";
+const TOGGLE_SELECTOR = '[data-spec="toggle-button"]';
 
 /**
  * Loads the Shopify Inbox (Shopify Chat) widget via the global loader script.
@@ -144,9 +148,17 @@ export function ShopifyInbox({
 }
 
 /**
- * Opens (toggles) the Shopify Inbox chat by clicking its bubble button. Returns
- * `true` when the button exists and was clicked, `false` otherwise (e.g. the
- * loader has not rendered the button yet, or Inbox is not configured).
+ * Opens the Shopify Inbox chat from your own UI (e.g. a "Message us" button).
+ * Returns `true` when a launcher was found and clicked, or the chat is already
+ * open; `false` otherwise (the widget has not rendered yet, or Inbox is not
+ * configured).
+ *
+ * Handles both widget states with Shopify-internal selectors:
+ * 1. Before the widget bundle loads, Shopify renders a placeholder bubble in a
+ *    same-origin iframe — clicking it lazy-loads and opens the full widget.
+ * 2. Once loaded (e.g. for returning visitors), the widget is an
+ *    `<inbox-online-store-chat>` web component whose launcher lives in an open
+ *    shadow root. The launcher toggles, so the click is skipped when open.
  *
  * There is no supported Shopify API to send or pre-fill a message from the
  * storefront — the chat composer runs in a Shopify-hosted, cross-origin context
@@ -156,14 +168,32 @@ export function openShopifyInbox(): boolean {
   if (typeof document === "undefined") {
     return false;
   }
+
+  // 1. Placeholder bubble inside the loader's same-origin iframe.
   const iframe = document.getElementById(
     BUBBLE_IFRAME_ID,
   ) as HTMLIFrameElement | null;
-  const button =
+  const bubbleButton =
     iframe?.contentWindow?.document?.getElementById(BUBBLE_BUTTON_ID);
-  if (button) {
-    button.click();
+  if (bubbleButton) {
+    bubbleButton.click();
     return true;
   }
+
+  // 2. Loaded web component: open it via the launcher in its shadow root,
+  //    unless the chat window is already open (the launcher toggles).
+  const widget = document.querySelector(WIDGET_TAG);
+  if (widget) {
+    if (widget.getAttribute("is-open") === "true") {
+      return true;
+    }
+    const launcher =
+      widget.shadowRoot?.querySelector<HTMLElement>(TOGGLE_SELECTOR);
+    if (launcher) {
+      launcher.click();
+      return true;
+    }
+  }
+
   return false;
 }


### PR DESCRIPTION
Follow-up to #436. Verifying the **Message us** button on the deployed storefront, I found `openShopifyInbox()` handled only one of the widget's two render states.

## Problem

Shopify Inbox renders differently depending on visitor state:

- **First-time visitor:** a placeholder bubble `#dummy-chat-button` inside a same-origin `#dummy-chat-button-iframe` — clicking it lazy-loads + opens the full widget.
- **Returning visitor / widget already loaded:** an `<inbox-online-store-chat>` **web component** (open shadow root, `is-open` attribute). No dummy bubble exists.

`openShopifyInbox()` only clicked `#dummy-chat-button`, so in the web-component state it returned `false` and the button did nothing.

## Fix

`openShopifyInbox()` now handles both:

1. Click the placeholder bubble in the same-origin iframe when present.
2. Otherwise click the `[data-spec="toggle-button"]` launcher inside `<inbox-online-store-chat>`'s shadow root — skipping the click when `is-open="true"` so it never toggles an open chat shut.

Selectors confirmed against the live `shopifyChatV1Widget.js` bundle (launcher = `<button data-spec="toggle-button" class="chat-toggle …">`) and the deployed `pilot.weaverse.dev` DOM. `is-open` is internal React state with no `observedAttributes`, so the attribute cannot be set externally — a click is required.

Doc (`.weaverse/docs/shopify-inbox.md`) updated to match.

## Verification

- `npx biome check` ✓ · `npx tsc --noEmit` ✓ · `npm run build` ✓
- Runtime DOM inspection on `pilot.weaverse.dev` confirmed both render states.
