### PR TITLE
fix(config): silence React Router v8 future-flag dev warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.6.24
+
+- [fix] Silence React Router v8 future-flag dev warnings by explicitly opting out of `v8_passThroughRequests` and `v8_trailingSlashAwareDataRequests` in `react-router.config.ts` (deep-merged over the Hydrogen preset; no behavior change)
+- [docs] Rewrite README for an agent-first quickstart, Weaverse MCP, and refreshed stack — drops the "Who is using Weaverse/Pilot on production?" section (#440)
+
 ## 2026.3.16
 
 - [feature] Switch versioning from semver to datetime-based (`YYYY.M.D`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.6.11",
+  "version": "2026.6.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weaverse/pilot",
-      "version": "2026.6.11",
+      "version": "2026.6.24",
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/cabin": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.6.11",
+  "version": "2026.6.24",
   "description": "A production-ready Shopify storefront built with Hydrogen and Weaverse",
   "keywords": [
     "shopify",

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -6,4 +6,20 @@ export default {
   appDirectory: "app",
   buildDirectory: "dist",
   ssr: true,
+  // React Router 7.16 warns about two v8 future flags the Hydrogen preset does
+  // not set. We explicitly opt out (the current resolved default) to silence the
+  // warnings without changing behavior. This is deep-merged over the preset's
+  // `future`, so its v8_middleware / v8_splitRouteModules stay enabled.
+  //   - v8_passThroughRequests: in v8, React Router stops normalizing
+  //     `request.url` (keeps the `.data` suffix + `_routes`/`index` params). This
+  //     app reads `request.url` in ~46 places (getPaginationVariables,
+  //     `new URL(request.url).searchParams` for collection filters, predictive
+  //     search, cart, and api routes), so enabling it needs an audit. Hydrogen's
+  //     preset has not validated it.
+  //   - v8_trailingSlashAwareDataRequests: changes the data-request URL format.
+  // Flip either to `true` only after verifying the affected loaders.
+  future: {
+    v8_passThroughRequests: false,
+    v8_trailingSlashAwareDataRequests: false,
+  },
 } satisfies Config;


### PR DESCRIPTION
## What & why

React Router 7.16 warns when the `v8_passThroughRequests` and `v8_trailingSlashAwareDataRequests` future flags are unset. The Hydrogen preset (`hydrogenPreset()`) sets `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, and `unstable_optimizeDeps` — but **not** these two — so `nr dev` logged both warnings on every config-loader pass.

## Fix

Explicitly opt out in `react-router.config.ts`:

```ts
future: {
  v8_passThroughRequests: false,
  v8_trailingSlashAwareDataRequests: false,
}
```

- Silences both warnings — they fire only when the flag is `undefined` (`@react-router/dev` `logFutureFlagWarnings`).
- **No behavior change**: the resolved default for both is already `false`.
- Deep-merged over the preset's `future` (merge order is `...presets, userConfig`), so `v8_middleware` / `v8_splitRouteModules` stay enabled.

**Opt-out, not opt-in, on purpose.** `v8_passThroughRequests` stops React Router normalizing `request.url` (keeps the `.data` suffix + `_routes`/`index` params), which would leak into the ~46 `request.url` reads in this app (`getPaginationVariables`, collection filters, predictive search, cart, api routes). Hydrogen has not validated it either. Flip either flag to `true` only after auditing those loaders — see the inline comment.

## Release 2026.6.24

- Bumped version `2026.6.11` → `2026.6.24` (+ `package-lock.json` via `npm i --package-lock-only --workspaces=false`).
- CHANGELOG updated.
- The README "Who is using Weaverse/Pilot on production?" section is already removed on `main` by the README rewrite in #440 — this branch is rebased onto it, so no README change is carried here; the changelog credits #440.

## Verification

- `nr dev` reaches its success banner with **0** `Future Flag Warning` lines (previously 2 per config pass).
- `biome check` ✓
- `tsc --noEmit` ✓
