### PR TITLE
Hide newsletter popup in Studio editor

### DIFF
--- a/app/components/root/newsletter-popup.tsx
+++ b/app/components/root/newsletter-popup.tsx
@@ -21,12 +21,15 @@ export function useShouldRenderNewsletterPopup() {
   const locale = data?.selectedLocale ?? DEFAULT_LOCALE;
   const { newsletterPopupEnabled, newsletterPopupHomeOnly } =
     useThemeSettings<ThemeSettings>();
+  const isDesignMode = useWeaverseStudioCheck();
   const pathParts = location.pathname.split("/").filter(Boolean);
   const isHomePage =
     pathParts.length === 0 ||
     (pathParts.length === 1 && pathParts[0] === locale.pathPrefix.slice(1));
   return (
-    newsletterPopupEnabled && (newsletterPopupHomeOnly ? isHomePage : true)
+    !isDesignMode &&
+    newsletterPopupEnabled &&
+    (newsletterPopupHomeOnly ? isHomePage : true)
   );
 }
 
@@ -104,24 +107,6 @@ export function NewsletterPopup() {
       }
     };
   }, []);
-
-  // Re-open popup when settings change in design mode
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Need to track all settings changes in design mode
-  useEffect(() => {
-    if (isDesignMode) {
-      setOpen(true);
-    }
-  }, [
-    newsletterPopupType,
-    newsletterPopupDelay,
-    newsletterPopupAllowDismiss,
-    newsletterPopupImage,
-    newsletterPopupImagePosition,
-    newsletterPopupHeading,
-    newsletterPopupDescription,
-    newsletterPopupButtonText,
-    newsletterPopupPosition,
-  ]);
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen} modal={isModal}>


### PR DESCRIPTION
## Summary
- Do not render the newsletter popup in Weaverse Studio design mode.
- Remove the design-mode force-open effect that bypassed the one-time display state inside the editor iframe.
- Keep normal storefront behavior unchanged: the popup records as seen when it actually opens.

## Verification
- `npm run typecheck`
- `npx biome check app/components/root/newsletter-popup.tsx`