### PR TITLE
build: prevent Oxygen deploy OOM on large storefronts (disable prod sourcemaps + doc heap fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Pilot is designed to be developed *with* an agent:
 
 ---
 
+## Getting started
+
 ## Commands
 
 ```bash
@@ -261,6 +263,19 @@ export const components: HydrogenComponent[] = [/* …existing, */ Video];
 
 - [Shopify Oxygen](https://weaverse.io/docs/deployment/oxygen) (recommended)
 - [Vercel](https://wvse.cc/deploy-pilot-to-vercel)
+
+> [!NOTE]
+> Large storefronts can hit a `JavaScript heap out of memory` error (exit code 134) during the Oxygen build. If that happens, raise Node's heap limit on the deploy step in the generated GitHub Actions workflow (`.github/workflows/oxygen-deployment-*.yml`):
+>
+> ```yaml
+> - name: Build and Publish to Oxygen
+>   run: npx shopify hydrogen deploy
+>   env:
+>     SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_... }}
+>     NODE_OPTIONS: --max-old-space-size=8192
+> ```
+>
+> Production sourcemaps are already disabled in `vite.config.ts` (`build.sourcemap: false`) to keep build memory down.
 
 ---
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,10 @@ export default defineConfig(({ isSsrBuild }) => ({
   },
   build: {
     assetsInlineLimit: 0,
+    // Disable sourcemaps in the production build. Sourcemap generation is a
+    // major memory driver and can push large storefronts past the CI runner's
+    // default Node heap (~2GB), causing OOM (exit 134) during Oxygen deploys.
+    sourcemap: false,
     ...(!isSsrBuild && {
       rollupOptions: {
         output: {


### PR DESCRIPTION
## Why
A client storefront built on this theme hit `FATAL ERROR: JavaScript heap out of memory` (exit 134) during the Oxygen deploy. The production build peaked above the CI runner's default Node heap (~2GB), so the deploy died before uploading a complete build. The environment then served HTML referencing client JS assets that were never published, and the storefront rendered blank (all `oxygen-v2/.../assets/*.js` returned 404).

To avoid other clients hitting the same wall on large storefronts, harden the base theme.

## Changes
1. `vite.config.ts` — `build.sourcemap: false`. Sourcemap generation is a major memory driver during the production build; disabling it lowers peak memory with no runtime cost.
2. `README.md` — document the heap fix (`NODE_OPTIONS: --max-old-space-size=8192` on the Oxygen deploy step) for storefronts large enough to still OOM. The deploy workflow is generated per-storefront by Shopify, so this can't live in the theme repo, but the note tells clients exactly where to add it.

## Notes
- `manualChunks` splitting is already present in this config and is kept.
- No behavior change at runtime; sourcemaps were only used for build-time debugging.
