### PR TITLE
Fix Spotify now-playing synchronization

### DIFF
--- a/data/snippets/using-spotify-api-to-display-currently-playing-track.mdx
+++ b/data/snippets/using-spotify-api-to-display-currently-playing-track.mdx
@@ -1,75 +1,146 @@
 ---
-heading: 'Display your currently playing Spotify track'
-title: 'Display your currently playing Spotify track'
+heading: 'Display Spotify currently playing track'
+title: "How to work with Spotify's API to display currently playing track on a website?"
 date: '2023-04-06'
-lastmod: '2026-07-23'
 icon: 'Spotify'
 draft: false
-summary: 'Generate a Spotify refresh token and use it to display your currently playing track.'
-tags: [spotify, nowplaying, spotify-api, oauth]
+summary: 'Retrieve a Spotify access token to display the currently playing track on your website or application.'
+tags: [spotify, nowplaying, spotify-api, nextjs]
 ---
 
-You need three server-side values to display your currently playing Spotify track:
-
-- `SPOTIFY_CLIENT_ID`
-- `SPOTIFY_CLIENT_SECRET`
-- `SPOTIFY_REFRESH_TOKEN`
+If you want to display your Spotify now playing track on your website, you need to get a token from Spotify.
+This token will be used to get the track information from Spotify API.
 
 ## Create a Spotify app
 
-Create an app in the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard), then add an HTTPS redirect URI such as:
+First, you need to create a Spotify app to get the credentials in order to generate the token.
 
-```text
-https://example.com
+- Go to [Spotify for Developers](https://developer.spotify.com/dashboard/applications) and login with your Spotify account.
+- Click on **Create app** button.
+- Fill the form and with the app name and description.
+- Add a redirect URI. This URI will be used to redirect to your local app after the authentication. For example, `https://example.com`.
+- Click on **Create** button.
+
+After creating the app, navigate to the **Settings** page and copy the `Client ID` and `Client secret`.
+We will use these values in the next step.
+
+![Spotify App](/static/images/spotify-app.png)
+
+## Authentication
+
+Since we only need to generate the token once, we will use the [Authorization Code Flow](https://developer.spotify.com/documentation/web-api/concepts/authorization#authorization-code-flow).
+Navigate to the following URL and replace the `CLIENT_ID` with your Spotify app `Client ID`:
+
+```bash
+https://accounts.spotify.com/authorize?client_id=CLIENT_ID&response_type=code&redirect_uri=https://example.com&scope=user-read-currently-playing
 ```
 
-Replace it with a URL you control. It must match exactly in the dashboard, authorization request, and token exchange.
+Remember to use the same redirect URI that you added to your Spotify app.
+In my case, it's `https://example.com`.
 
-Open the following URL after replacing `CLIENT_ID` and the encoded redirect URI:
+![Spotify auth](/static/images/spotify-auth.png)
 
-```text
-https://accounts.spotify.com/authorize?client_id=CLIENT_ID&response_type=code&redirect_uri=https%3A%2F%2Fexample.com&scope=user-read-currently-playing%20user-read-recently-played
+After the authentication process, you will be redirected to the redirect URI with a `code` query parameter.
+The redirect URI will look like this:
+
+```bash
+https://example.com/?code=a1b2c...i9j0
 ```
 
-Approve access. Spotify will redirect you back with a short-lived `code` query parameter:
+![Spotify code](/static/images/spotify-code.png)
 
-```text
-https://example.com/?code=AQD...
-```
+Save this `code` value, we will use it in the next step.
 
-## Quick option: exchange the code in DevTools
+Next step is to send a POST request to the Spotify API to get the token. We'll simply open a new tab in the browser and send the request using the `fetch` API in the browser developer tools.
 
-This is the fastest option for a one-time personal setup. It temporarily exposes your client secret to your browser, so only use it on your own machine and browser profile. Do not use an online Base64 tool.
+Run this code in the **Console** tab of the browser developer tools:
 
-Open browser DevTools, replace the four values, and run:
+```js:spotify.js {3,18} showLineNumbers
+let data = {
+  grant_type: 'authorization_code',
+  code: 'AQB....GemX',
+  redirect_uri: 'https://example.com',
+}
 
-```js:spotify-auth.js showLineNumbers
-const clientId = 'your_spotify_client_id'
-const clientSecret = 'your_spotify_client_secret'
-const code = 'code_from_the_callback_url'
-const redirectUri = 'https://example.com'
+let formData = []
+for (let prop in data) {
+  let encodedKey = encodeURIComponent(prop)
+  let encodedValue = encodeURIComponent(data[prop])
+  formData.push(encodedKey + '=' + encodedValue)
+}
+formData = formData.join('&')
 
-const basic = btoa(`${clientId}:${clientSecret}`)
-const response = await fetch('https://accounts.spotify.com/api/token', {
+fetch('https://accounts.spotify.com/api/token', {
   method: 'POST',
   headers: {
-    Authorization: `Basic ${basic}`,
+    Authorization: 'Basic <base64 encoded client_id:client_secret>',
     'Content-Type': 'application/x-www-form-urlencoded',
   },
-  body: new URLSearchParams({
-    grant_type: 'authorization_code',
-    code,
-    redirect_uri: redirectUri,
-  }),
+  body: formData,
 })
-
-const token = await response.json()
-if (!response.ok) throw new Error(token.error_description ?? token.error)
-
-console.log(token.refresh_token)
 ```
 
-Copy the refresh token into `.env`, then clear the console:
+Replace the code in line 3 with the `code` value that you saved in the previous step.
+
+Replace the `<base64 encoded client_id:client_secret>` in line 18 with the base64 encoded value of your Spotify app `Client ID` and `Client secret`.
+You can use this [online tool](https://www.base64encode.org/) to encode the value.
+
+![Base64 encode tool](/static/images/spotify-base64-encode.png)
+
+The value format should be `client_id:client_secret`
+
+The request will return a response containing a `refresh_token`, this token is valid indefinitely unless you revoke it or you change the password of your Spotify account.
+
+## Querying the nowplaying track
+
+Now that we have the token, we can use it to fetch the now playing track from Spotify API.
+Use this code to fetch the now playing track in your node server:
+
+```js:spotify.js showLineNumbers
+import fetch from 'isomorphic-unfetch'
+
+let SPOTIFY_TOKEN_API = `https://accounts.spotify.com/api/token`
+let SPOTIFY_NOW_PLAYING_API = `https://api.spotify.com/v1/me/player/currently-playing`
+let SPOTIFY_TOP_TRACKS_API = `https://api.spotify.com/v1/me/top/tracks`
+
+let {
+  SPOTIFY_CLIENT_ID: client_id,
+  SPOTIFY_CLIENT_SECRET: client_secret,
+  SPOTIFY_REFRESH_TOKEN: refresh_token,
+} = process.env
+
+let basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64')
+
+async function getAccessToken() {
+  let response = await fetch(SPOTIFY_TOKEN_API, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token,
+    }),
+  })
+
+  return response.json()
+}
+
+export async function getNowPlaying() {
+  let { access_token } = await getAccessToken()
+  let url = new URL(SPOTIFY_NOW_PLAYING_API)
+  url.searchParams.append('additional_types', 'track,episode')
+
+  return fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+    },
+  })
+}
+```
+
+Remember to add the required environment variables to your `.env` file.
 
 ```bash:.env showLineNumbers
 SPOTIFY_CLIENT_ID=your_spotify_client_id
@@ -77,106 +148,6 @@ SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
 SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
 ```
 
-Never commit `.env`.
+That's it! Now you can use the `getNowPlaying` function to fetch the now playing track from Spotify API.
 
-## Safer option: exchange it locally
-
-If you do not want the client secret to enter your browser, save this optional script as `spotify-auth.ts`. Bun automatically loads your local `.env` file.
-
-```ts:spotify-auth.ts showLineNumbers
-const clientId = process.env.SPOTIFY_CLIENT_ID
-const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-const redirectUri = process.env.SPOTIFY_REDIRECT_URI
-const code = prompt('Authorization code:')
-
-if (!clientId || !clientSecret || !redirectUri || !code) {
-  throw new Error('Missing Spotify credentials, redirect URI, or code')
-}
-
-const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
-const response = await fetch('https://accounts.spotify.com/api/token', {
-  method: 'POST',
-  headers: {
-    Authorization: `Basic ${basic}`,
-    'Content-Type': 'application/x-www-form-urlencoded',
-  },
-  body: new URLSearchParams({
-    grant_type: 'authorization_code',
-    code,
-    redirect_uri: redirectUri,
-  }),
-})
-
-const token = (await response.json()) as {
-  error?: string
-  error_description?: string
-  refresh_token?: string
-}
-
-if (!response.ok || !token.refresh_token) {
-  throw new Error(token.error_description ?? token.error ?? 'Token exchange failed')
-}
-
-console.log(`SPOTIFY_REFRESH_TOKEN=${token.refresh_token}`)
-```
-
-Add `SPOTIFY_REDIRECT_URI` to `.env`, then run `bun spotify-auth.ts`. Paste the authorization code when prompted and copy the resulting line back into `.env`.
-
-## Query the currently playing track
-
-Use the refresh token only from server-side code:
-
-```ts:spotify.ts showLineNumbers
-const TOKEN_API = 'https://accounts.spotify.com/api/token'
-const NOW_PLAYING_API = 'https://api.spotify.com/v1/me/player/currently-playing'
-
-async function getAccessToken() {
-  const clientId = process.env.SPOTIFY_CLIENT_ID
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-  const refreshToken = process.env.SPOTIFY_REFRESH_TOKEN
-
-  if (!clientId || !clientSecret || !refreshToken) {
-    throw new Error('Spotify credentials are not configured')
-  }
-
-  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
-  const response = await fetch(TOKEN_API, {
-    method: 'POST',
-    cache: 'no-store',
-    headers: {
-      Authorization: `Basic ${basic}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-    }),
-  })
-
-  if (!response.ok) throw new Error(`Spotify token refresh failed (${response.status})`)
-
-  const token = (await response.json()) as {access_token?: string}
-  if (!token.access_token) throw new Error('Spotify returned no access token')
-
-  return token.access_token
-}
-
-export async function getNowPlaying() {
-  const accessToken = await getAccessToken()
-  const response = await fetch(`${NOW_PLAYING_API}?additional_types=track,episode`, {
-    cache: 'no-store',
-    headers: {Authorization: `Bearer ${accessToken}`},
-  })
-
-  if (response.status === 204) return null
-  if (!response.ok) throw new Error(`Spotify request failed (${response.status})`)
-
-  return response.json()
-}
-```
-
-Return this data through your own server endpoint. For live playback state, use `Cache-Control: private, no-store, max-age=0`, refresh when the page regains focus, and poll every 15–30 seconds while the widget is visible.
-
-When there is no active track, you can optionally call `/v1/me/player/recently-played?limit=1`. That fallback needs the `user-read-recently-played` scope included above.
-
-Refresh tokens can be revoked. If Spotify returns `invalid_grant`, authorize again instead of reporting the credentials as missing.
+Happy playing! <Twemoji emoji="clinking-beer-mugs" />

--- a/data/snippets/using-spotify-api-to-display-currently-playing-track.mdx
+++ b/data/snippets/using-spotify-api-to-display-currently-playing-track.mdx
@@ -5,7 +5,7 @@ date: '2023-04-06'
 lastmod: '2026-07-23'
 icon: 'Spotify'
 draft: false
-summary: 'Generate a Spotify refresh token safely and use it to display your currently playing track.'
+summary: 'Generate a Spotify refresh token and use it to display your currently playing track.'
 tags: [spotify, nowplaying, spotify-api, oauth]
 ---
 
@@ -15,8 +15,6 @@ You need three server-side values to display your currently playing Spotify trac
 - `SPOTIFY_CLIENT_SECRET`
 - `SPOTIFY_REFRESH_TOKEN`
 
-The client ID can appear in an authorization URL. The client secret and refresh token must stay on your server or local machine.
-
 ## Create a Spotify app
 
 Create an app in the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard), then add an HTTPS redirect URI such as:
@@ -25,57 +23,75 @@ Create an app in the [Spotify Developer Dashboard](https://developer.spotify.com
 https://example.com
 ```
 
-Replace it with a URL you control. The redirect URI must match exactly in the dashboard, authorization request, and token exchange.
+Replace it with a URL you control. It must match exactly in the dashboard, authorization request, and token exchange.
 
-Create a local `.env` file and make sure it is ignored by Git:
+Open the following URL after replacing `CLIENT_ID` and the encoded redirect URI:
+
+```text
+https://accounts.spotify.com/authorize?client_id=CLIENT_ID&response_type=code&redirect_uri=https%3A%2F%2Fexample.com&scope=user-read-currently-playing%20user-read-recently-played
+```
+
+Approve access. Spotify will redirect you back with a short-lived `code` query parameter:
+
+```text
+https://example.com/?code=AQD...
+```
+
+## Quick option: exchange the code in DevTools
+
+This is the fastest option for a one-time personal setup. It temporarily exposes your client secret to your browser, so only use it on your own machine and browser profile. Do not use an online Base64 tool.
+
+Open browser DevTools, replace the four values, and run:
+
+```js:spotify-auth.js showLineNumbers
+const clientId = 'your_spotify_client_id'
+const clientSecret = 'your_spotify_client_secret'
+const code = 'code_from_the_callback_url'
+const redirectUri = 'https://example.com'
+
+const basic = btoa(`${clientId}:${clientSecret}`)
+const response = await fetch('https://accounts.spotify.com/api/token', {
+  method: 'POST',
+  headers: {
+    Authorization: `Basic ${basic}`,
+    'Content-Type': 'application/x-www-form-urlencoded',
+  },
+  body: new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+  }),
+})
+
+const token = await response.json()
+if (!response.ok) throw new Error(token.error_description ?? token.error)
+
+console.log(token.refresh_token)
+```
+
+Copy the refresh token into `.env`, then clear the console:
 
 ```bash:.env showLineNumbers
 SPOTIFY_CLIENT_ID=your_spotify_client_id
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
-SPOTIFY_REDIRECT_URI=https://example.com
+SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
 ```
 
-## Generate a refresh token
+Never commit `.env`.
 
-Do not exchange the authorization code in browser DevTools. That would expose your client secret to the browser. Base64 also does not encrypt a secret.
+## Safer option: exchange it locally
 
-Instead, save this one-time local script as `spotify-auth.ts`:
+If you do not want the client secret to enter your browser, save this optional script as `spotify-auth.ts`. Bun automatically loads your local `.env` file.
 
 ```ts:spotify-auth.ts showLineNumbers
-import { randomBytes } from 'node:crypto'
-import { createInterface } from 'node:readline/promises'
-
 const clientId = process.env.SPOTIFY_CLIENT_ID
 const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
 const redirectUri = process.env.SPOTIFY_REDIRECT_URI
+const code = prompt('Authorization code:')
 
-if (!clientId || !clientSecret || !redirectUri) {
-  throw new Error('Missing Spotify values in .env')
+if (!clientId || !clientSecret || !redirectUri || !code) {
+  throw new Error('Missing Spotify credentials, redirect URI, or code')
 }
-
-const state = randomBytes(16).toString('hex')
-const authorizeUrl = new URL('https://accounts.spotify.com/authorize')
-authorizeUrl.search = new URLSearchParams({
-  client_id: clientId,
-  response_type: 'code',
-  redirect_uri: redirectUri,
-  scope: 'user-read-currently-playing user-read-recently-played',
-  state,
-}).toString()
-
-console.log(`Open this URL:\n\n${authorizeUrl}\n`)
-
-const terminal = createInterface({input: process.stdin, output: process.stdout})
-const callbackInput = await terminal.question('Paste the full callback URL: ')
-terminal.close()
-
-const callbackUrl = new URL(callbackInput)
-if (callbackUrl.searchParams.get('state') !== state) {
-  throw new Error('Invalid OAuth state')
-}
-
-const code = callbackUrl.searchParams.get('code')
-if (!code) throw new Error('Missing authorization code')
 
 const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
 const response = await fetch('https://accounts.spotify.com/api/token', {
@@ -91,32 +107,20 @@ const response = await fetch('https://accounts.spotify.com/api/token', {
   }),
 })
 
-if (!response.ok) {
-  throw new Error(`Spotify token exchange failed (${response.status})`)
+const token = (await response.json()) as {
+  error?: string
+  error_description?: string
+  refresh_token?: string
 }
 
-const token = (await response.json()) as {refresh_token?: string}
-if (!token.refresh_token) throw new Error('Spotify did not return a refresh token')
+if (!response.ok || !token.refresh_token) {
+  throw new Error(token.error_description ?? token.error ?? 'Token exchange failed')
+}
 
-const env = await Bun.file('.env').text()
-const refreshToken = `SPOTIFY_REFRESH_TOKEN=${JSON.stringify(token.refresh_token)}`
-const nextEnv = /^SPOTIFY_REFRESH_TOKEN=.*$/m.test(env)
-  ? env.replace(/^SPOTIFY_REFRESH_TOKEN=.*$/m, refreshToken)
-  : `${env.trimEnd()}\n${refreshToken}\n`
-
-await Bun.write('.env', nextEnv)
-console.log('Saved SPOTIFY_REFRESH_TOKEN to .env')
+console.log(`SPOTIFY_REFRESH_TOKEN=${token.refresh_token}`)
 ```
 
-Run it with [Bun](https://bun.sh/):
-
-```bash
-bun spotify-auth.ts
-```
-
-Open the URL printed by the script, approve access, then paste the full redirected URL back into the terminal. The script validates the OAuth state and saves the refresh token directly to `.env` without printing it.
-
-Delete the script if you no longer need it, and never commit `.env`.
+Add `SPOTIFY_REDIRECT_URI` to `.env`, then run `bun spotify-auth.ts`. Paste the authorization code when prompted and copy the resulting line back into `.env`.
 
 ## Query the currently playing track
 
@@ -149,9 +153,7 @@ async function getAccessToken() {
     }),
   })
 
-  if (!response.ok) {
-    throw new Error(`Spotify token refresh failed (${response.status})`)
-  }
+  if (!response.ok) throw new Error(`Spotify token refresh failed (${response.status})`)
 
   const token = (await response.json()) as {access_token?: string}
   if (!token.access_token) throw new Error('Spotify returned no access token')
@@ -173,8 +175,8 @@ export async function getNowPlaying() {
 }
 ```
 
-Return this data through your own server endpoint. For live playback state, send `Cache-Control: private, no-store, max-age=0` and refresh the UI when the page loads, regains focus, or becomes visible. A 15–30 second poll while the widget is visible is usually enough.
+Return this data through your own server endpoint. For live playback state, use `Cache-Control: private, no-store, max-age=0`, refresh when the page regains focus, and poll every 15–30 seconds while the widget is visible.
 
-When Spotify returns no active track, you can optionally call `/v1/me/player/recently-played?limit=1`. That fallback requires the `user-read-recently-played` scope included above.
+When there is no active track, you can optionally call `/v1/me/player/recently-played?limit=1`. That fallback needs the `user-read-recently-played` scope included above.
 
-Refresh tokens can be revoked. If Spotify returns `invalid_grant`, run the authorization script again instead of reporting the credentials as missing.
+Refresh tokens can be revoked. If Spotify returns `invalid_grant`, authorize again instead of reporting the credentials as missing.

--- a/data/snippets/using-spotify-api-to-display-currently-playing-track.mdx
+++ b/data/snippets/using-spotify-api-to-display-currently-playing-track.mdx
@@ -1,153 +1,180 @@
 ---
-heading: 'Display Spotify currently playing track'
-title: "How to work with Spotify's API to display currently playing track on a website?"
+heading: 'Display your currently playing Spotify track'
+title: 'Display your currently playing Spotify track'
 date: '2023-04-06'
+lastmod: '2026-07-23'
 icon: 'Spotify'
 draft: false
-summary: 'Retrieve a Spotify access token to display the currently playing track on your website or application.'
-tags: [spotify, nowplaying, spotify-api, nextjs]
+summary: 'Generate a Spotify refresh token safely and use it to display your currently playing track.'
+tags: [spotify, nowplaying, spotify-api, oauth]
 ---
 
-If you want to display your Spotify now playing track on your website, you need to get a token from Spotify.
-This token will be used to get the track information from Spotify API.
+You need three server-side values to display your currently playing Spotify track:
+
+- `SPOTIFY_CLIENT_ID`
+- `SPOTIFY_CLIENT_SECRET`
+- `SPOTIFY_REFRESH_TOKEN`
+
+The client ID can appear in an authorization URL. The client secret and refresh token must stay on your server or local machine.
 
 ## Create a Spotify app
 
-First, you need to create a Spotify app to get the credentials in order to generate the token.
+Create an app in the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard), then add an HTTPS redirect URI such as:
 
-- Go to [Spotify for Developers](https://developer.spotify.com/dashboard/applications) and login with your Spotify account.
-- Click on **Create app** button.
-- Fill the form and with the app name and description.
-- Add a redirect URI. This URI will be used to redirect to your local app after the authentication. For example, `http://localhost:3434`.
-- Click on **Create** button.
-
-After creating the app, navigate to the **Settings** page and copy the `Client ID` and `Client secret`.
-We will use these values in the next step.
-
-![Spotify App](/static/images/spotify-app.png)
-
-## Authentication
-
-Since we only need to generate the token once, we will use the [Authorization Code Flow](https://developer.spotify.com/documentation/web-api/concepts/authorization#authorization-code-flow).
-Navigate to the following URL and replace the `CLIENT_ID` with your Spotify app `Client ID`:
-
-```bash
-https://accounts.spotify.com/authorize?client_id=CLIENT_ID&response_type=code&redirect_uri=http://localhost:3434&scope=user-read-currently-playing
+```text
+https://example.com
 ```
 
-Remember to use the same redirect URI that you added to your Spotify app.
-In my case, it's `http://localhost:3434`.
+Replace it with a URL you control. The redirect URI must match exactly in the dashboard, authorization request, and token exchange.
 
-![Spotify auth](/static/images/spotify-auth.png)
+Create a local `.env` file and make sure it is ignored by Git:
 
-After the authentication process, you will be redirected to the redirect URI with a `code` query parameter.
-The redirect URI will look like this:
-
-```bash
-http://localhost:3434/?code=a1b2c...i9j0
+```bash:.env showLineNumbers
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+SPOTIFY_REDIRECT_URI=https://example.com
 ```
 
-![Spotify code](/static/images/spotify-code.png)
+## Generate a refresh token
 
-Save this `code` value, we will use it in the next step.
+Do not exchange the authorization code in browser DevTools. That would expose your client secret to the browser. Base64 also does not encrypt a secret.
 
-Next step is to send a POST request to the Spotify API to get the token. We'll simply open a new tab in the browser and send the request using the `fetch` API in the browser developer tools.
+Instead, save this one-time local script as `spotify-auth.ts`:
 
-Run this code in the **Console** tab of the browser developer tools:
+```ts:spotify-auth.ts showLineNumbers
+import { randomBytes } from 'node:crypto'
+import { createInterface } from 'node:readline/promises'
 
-```js:spotify.js {3,18} showLineNumbers
-let data = {
-  grant_type: 'authorization_code',
-  code: 'AQB....GemX',
-  redirect_uri: 'http://localhost:3434',
+const clientId = process.env.SPOTIFY_CLIENT_ID
+const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
+const redirectUri = process.env.SPOTIFY_REDIRECT_URI
+
+if (!clientId || !clientSecret || !redirectUri) {
+  throw new Error('Missing Spotify values in .env')
 }
 
-let formData = []
-for (let prop in data) {
-  let encodedKey = encodeURIComponent(prop)
-  let encodedValue = encodeURIComponent(data[prop])
-  formData.push(encodedKey + '=' + encodedValue)
-}
-formData = formData.join('&')
+const state = randomBytes(16).toString('hex')
+const authorizeUrl = new URL('https://accounts.spotify.com/authorize')
+authorizeUrl.search = new URLSearchParams({
+  client_id: clientId,
+  response_type: 'code',
+  redirect_uri: redirectUri,
+  scope: 'user-read-currently-playing user-read-recently-played',
+  state,
+}).toString()
 
-fetch('https://accounts.spotify.com/api/token', {
+console.log(`Open this URL:\n\n${authorizeUrl}\n`)
+
+const terminal = createInterface({input: process.stdin, output: process.stdout})
+const callbackInput = await terminal.question('Paste the full callback URL: ')
+terminal.close()
+
+const callbackUrl = new URL(callbackInput)
+if (callbackUrl.searchParams.get('state') !== state) {
+  throw new Error('Invalid OAuth state')
+}
+
+const code = callbackUrl.searchParams.get('code')
+if (!code) throw new Error('Missing authorization code')
+
+const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+const response = await fetch('https://accounts.spotify.com/api/token', {
   method: 'POST',
   headers: {
-    Authorization: 'Basic <base64 encoded client_id:client_secret>',
+    Authorization: `Basic ${basic}`,
     'Content-Type': 'application/x-www-form-urlencoded',
   },
-  body: formData,
+  body: new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+  }),
 })
+
+if (!response.ok) {
+  throw new Error(`Spotify token exchange failed (${response.status})`)
+}
+
+const token = (await response.json()) as {refresh_token?: string}
+if (!token.refresh_token) throw new Error('Spotify did not return a refresh token')
+
+const env = await Bun.file('.env').text()
+const refreshToken = `SPOTIFY_REFRESH_TOKEN=${JSON.stringify(token.refresh_token)}`
+const nextEnv = /^SPOTIFY_REFRESH_TOKEN=.*$/m.test(env)
+  ? env.replace(/^SPOTIFY_REFRESH_TOKEN=.*$/m, refreshToken)
+  : `${env.trimEnd()}\n${refreshToken}\n`
+
+await Bun.write('.env', nextEnv)
+console.log('Saved SPOTIFY_REFRESH_TOKEN to .env')
 ```
 
-Replace the code in line 3 with the `code` value that you saved in the previous step.
+Run it with [Bun](https://bun.sh/):
 
-Replace the `<base64 encoded client_id:client_secret>` in line 18 with the base64 encoded value of your Spotify app `Client ID` and `Client secret`.
-You can use this [online tool](https://www.base64encode.org/) to encode the value.
+```bash
+bun spotify-auth.ts
+```
 
-![Base64 encode tool](/static/images/spotify-base64-encode.png)
+Open the URL printed by the script, approve access, then paste the full redirected URL back into the terminal. The script validates the OAuth state and saves the refresh token directly to `.env` without printing it.
 
-The value format should be `client_id:client_secret`
+Delete the script if you no longer need it, and never commit `.env`.
 
-The request will return a response containing a `refresh_token`, this token is valid indefinitely unless you revoke it or you change the password of your Spotify account.
+## Query the currently playing track
 
-## Querying the nowplaying track
+Use the refresh token only from server-side code:
 
-Now that we have the token, we can use it to fetch the now playing track from Spotify API.
-Use this code to fetch the now playing track in your node server:
-
-```js:spotify.js showLineNumbers
-import fetch from 'isomorphic-unfetch'
-
-let SPOTIFY_TOKEN_API = `https://accounts.spotify.com/api/token`
-let SPOTIFY_NOW_PLAYING_API = `https://api.spotify.com/v1/me/player/currently-playing`
-let SPOTIFY_TOP_TRACKS_API = `https://api.spotify.com/v1/me/top/tracks`
-
-let {
-  SPOTIFY_CLIENT_ID: client_id,
-  SPOTIFY_CLIENT_SECRET: client_secret,
-  SPOTIFY_REFRESH_TOKEN: refresh_token,
-} = process.env
-
-let basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64')
+```ts:spotify.ts showLineNumbers
+const TOKEN_API = 'https://accounts.spotify.com/api/token'
+const NOW_PLAYING_API = 'https://api.spotify.com/v1/me/player/currently-playing'
 
 async function getAccessToken() {
-  let response = await fetch(SPOTIFY_TOKEN_API, {
+  const clientId = process.env.SPOTIFY_CLIENT_ID
+  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
+  const refreshToken = process.env.SPOTIFY_REFRESH_TOKEN
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    throw new Error('Spotify credentials are not configured')
+  }
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+  const response = await fetch(TOKEN_API, {
     method: 'POST',
+    cache: 'no-store',
     headers: {
       Authorization: `Basic ${basic}`,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: new URLSearchParams({
       grant_type: 'refresh_token',
-      refresh_token,
+      refresh_token: refreshToken,
     }),
   })
 
-  return response.json()
+  if (!response.ok) {
+    throw new Error(`Spotify token refresh failed (${response.status})`)
+  }
+
+  const token = (await response.json()) as {access_token?: string}
+  if (!token.access_token) throw new Error('Spotify returned no access token')
+
+  return token.access_token
 }
 
 export async function getNowPlaying() {
-  let { access_token } = await getAccessToken()
-  let url = new URL(SPOTIFY_NOW_PLAYING_API)
-  url.searchParams.append('additional_types', 'track,episode')
-
-  return fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${access_token}`,
-    },
+  const accessToken = await getAccessToken()
+  const response = await fetch(`${NOW_PLAYING_API}?additional_types=track,episode`, {
+    cache: 'no-store',
+    headers: {Authorization: `Bearer ${accessToken}`},
   })
+
+  if (response.status === 204) return null
+  if (!response.ok) throw new Error(`Spotify request failed (${response.status})`)
+
+  return response.json()
 }
 ```
 
-Remember to add the required environment variables to your `.env` file.
+Return this data through your own server endpoint. For live playback state, send `Cache-Control: private, no-store, max-age=0` and refresh the UI when the page loads, regains focus, or becomes visible. A 15–30 second poll while the widget is visible is usually enough.
 
-```bash:.env showLineNumbers
-SPOTIFY_CLIENT_ID=your_spotify_client_id
-SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
-SPOTIFY_REFRESH_TOKEN=your_spotify_refresh_token
-```
+When Spotify returns no active track, you can optionally call `/v1/me/player/recently-played?limit=1`. That fallback requires the `user-read-recently-played` scope included above.
 
-That's it! Now you can use the `getNowPlaying` function to fetch the now playing track from Spotify API.
-
-Happy playing! <Twemoji emoji="clinking-beer-mugs" />
+Refresh tokens can be revoked. If Spotify returns `invalid_grant`, run the authorization script again instead of reporting the credentials as missing.

--- a/src/components/studio/runtime-rail/client/hydrate.ts
+++ b/src/components/studio/runtime-rail/client/hydrate.ts
@@ -1,7 +1,7 @@
 import { updateActivity } from './activity'
 import { updateGithub } from './github/heat'
 import { fetchRuntimeJson } from './shared'
-import { refreshSpotify, SPOTIFY_REFRESH_INTERVAL } from './spotify'
+import { syncSpotify } from './spotify-sync'
 import { updateTokenBurn } from './token-burn'
 import type {
   ActivityPayload,
@@ -9,8 +9,6 @@ import type {
   GithubTodayPayload,
   TokenBurnPayload,
 } from './types'
-
-let spotifyTimer: number | null = null
 
 function hydrateGithubActivity(rail: HTMLElement) {
   if (rail.dataset.hydrated === 'true') return
@@ -50,14 +48,8 @@ function hydrateRuntimeRail() {
   hydrateGithubActivity(rail)
   // token-burn is static for the session too — fetch once, independently.
   hydrateTokenBurn(rail)
-  // Spotify is live — refresh now and keep a single interval running.
-  refreshSpotify(rail)
-  if (spotifyTimer === null) {
-    spotifyTimer = window.setInterval(() => {
-      const current = document.querySelector('#runtime-rail')
-      if (current) refreshSpotify(current)
-    }, SPOTIFY_REFRESH_INTERVAL)
-  }
+  // Spotify stays live across persisted-rail navigation and browser focus.
+  syncSpotify()
 }
 
 document.addEventListener('astro:page-load', hydrateRuntimeRail)

--- a/src/components/studio/runtime-rail/client/spotify-sync.test.ts
+++ b/src/components/studio/runtime-rail/client/spotify-sync.test.ts
@@ -1,0 +1,164 @@
+// @ts-nocheck -- Bun's test globals are not part of the Astro app tsconfig.
+import { describe, expect, test } from 'bun:test'
+import {
+  createSpotifySync,
+  SPOTIFY_REFRESH_INTERVAL,
+  type SpotifySyncEnvironment,
+} from './spotify-sync'
+
+type Listener = () => void
+
+class FakeEnvironment implements SpotifySyncEnvironment {
+  visible = true
+  rail: Element | null = {} as Element
+  readonly errors: unknown[] = []
+  readonly windowListeners = new Map<string, Listener[]>()
+  readonly documentListeners = new Map<string, Listener[]>()
+  readonly intervals: Array<{ callback: Listener; delay: number }> = []
+
+  getRail = () => this.rail
+  isVisible = () => this.visible
+
+  addWindowListener = (type: 'focus' | 'online', listener: Listener) => {
+    const listeners = this.windowListeners.get(type) ?? []
+    listeners.push(listener)
+    this.windowListeners.set(type, listeners)
+  }
+
+  addDocumentListener = (type: 'visibilitychange', listener: Listener) => {
+    const listeners = this.documentListeners.get(type) ?? []
+    listeners.push(listener)
+    this.documentListeners.set(type, listeners)
+  }
+
+  setInterval = (callback: Listener, delay: number) => {
+    this.intervals.push({ callback, delay })
+  }
+
+  reportError = (error: unknown) => {
+    this.errors.push(error)
+  }
+
+  emitWindow(type: 'focus' | 'online') {
+    for (const listener of this.windowListeners.get(type) ?? []) listener()
+  }
+
+  emitDocument(type: 'visibilitychange') {
+    for (const listener of this.documentListeners.get(type) ?? []) listener()
+  }
+
+  tick() {
+    for (const interval of this.intervals) interval.callback()
+  }
+}
+
+const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve))
+
+describe('Spotify runtime sync', () => {
+  test('refreshes on start, focus, visibility, online, and a 15-second interval', async () => {
+    const environment = new FakeEnvironment()
+    let calls = 0
+    const sync = createSpotifySync(async () => {
+      calls += 1
+    }, environment)
+
+    sync.start()
+    await flush()
+    expect(calls).toBe(1)
+    expect(environment.intervals).toHaveLength(1)
+    expect(environment.intervals[0]?.delay).toBe(SPOTIFY_REFRESH_INTERVAL)
+
+    environment.emitWindow('focus')
+    await flush()
+    expect(calls).toBe(2)
+
+    environment.emitWindow('online')
+    await flush()
+    expect(calls).toBe(3)
+
+    environment.visible = false
+    environment.emitDocument('visibilitychange')
+    environment.tick()
+    await flush()
+    expect(calls).toBe(3)
+
+    environment.visible = true
+    environment.emitDocument('visibilitychange')
+    await flush()
+    expect(calls).toBe(4)
+
+    environment.tick()
+    await flush()
+    expect(calls).toBe(5)
+  })
+
+  test('deduplicates focus, navigation, and interval refreshes while one is in flight', async () => {
+    const environment = new FakeEnvironment()
+    let calls = 0
+    let resolveRequest: (() => void) | undefined
+    const sync = createSpotifySync(
+      () => {
+        calls += 1
+        return new Promise<void>((resolve) => {
+          resolveRequest = resolve
+        })
+      },
+      environment,
+    )
+
+    sync.start()
+    sync.start()
+    environment.emitWindow('focus')
+    environment.emitWindow('online')
+    environment.tick()
+    expect(calls).toBe(1)
+    expect(environment.windowListeners.get('focus')).toHaveLength(1)
+    expect(environment.windowListeners.get('online')).toHaveLength(1)
+    expect(environment.documentListeners.get('visibilitychange')).toHaveLength(1)
+    expect(environment.intervals).toHaveLength(1)
+
+    resolveRequest?.()
+    await flush()
+    environment.emitWindow('focus')
+    expect(calls).toBe(2)
+  })
+
+  test('skips refreshes when the rail is not rendered', async () => {
+    const environment = new FakeEnvironment()
+    environment.rail = null
+    let calls = 0
+    const sync = createSpotifySync(async () => {
+      calls += 1
+    }, environment)
+
+    sync.start()
+    environment.emitWindow('focus')
+    environment.tick()
+    await flush()
+    expect(calls).toBe(0)
+
+    environment.rail = {} as Element
+    environment.emitWindow('focus')
+    await flush()
+    expect(calls).toBe(1)
+  })
+
+  test('reports refresh failures without blocking the next refresh', async () => {
+    const environment = new FakeEnvironment()
+    let calls = 0
+    const failure = new Error('Spotify failed')
+    const sync = createSpotifySync(async () => {
+      calls += 1
+      if (calls === 1) throw failure
+    }, environment)
+
+    sync.start()
+    await flush()
+    await flush()
+    expect(environment.errors).toEqual([failure])
+
+    environment.emitWindow('focus')
+    await flush()
+    expect(calls).toBe(2)
+  })
+})

--- a/src/components/studio/runtime-rail/client/spotify-sync.ts
+++ b/src/components/studio/runtime-rail/client/spotify-sync.ts
@@ -1,4 +1,5 @@
 import { refreshSpotify } from './spotify'
+import { preserveSpotifyWave } from './spotify-wave'
 
 export const SPOTIFY_REFRESH_INTERVAL = 15 * 1000
 
@@ -83,5 +84,6 @@ const browserSpotifySync = createSpotifySync(
 )
 
 export function syncSpotify() {
+  preserveSpotifyWave()
   browserSpotifySync.start()
 }

--- a/src/components/studio/runtime-rail/client/spotify-sync.ts
+++ b/src/components/studio/runtime-rail/client/spotify-sync.ts
@@ -1,0 +1,87 @@
+import { refreshSpotify } from './spotify'
+
+export const SPOTIFY_REFRESH_INTERVAL = 15 * 1000
+
+type Listener = () => void
+
+export interface SpotifySyncEnvironment {
+  getRail: () => Element | null
+  isVisible: () => boolean
+  addWindowListener: (type: 'focus' | 'online', listener: Listener) => void
+  addDocumentListener: (
+    type: 'visibilitychange',
+    listener: Listener,
+  ) => void
+  setInterval: (callback: Listener, delay: number) => void
+  reportError: (error: unknown) => void
+}
+
+export function createSpotifySync(
+  refresh: (rail: Element) => Promise<void>,
+  environment: SpotifySyncEnvironment,
+) {
+  let started = false
+  let inFlight: Promise<void> | null = null
+
+  function refreshCurrent(): Promise<void> {
+    if (!environment.isVisible()) return Promise.resolve()
+    if (inFlight) return inFlight
+
+    const rail = environment.getRail()
+    if (!rail) return Promise.resolve()
+
+    let request: Promise<void>
+    try {
+      request = Promise.resolve(refresh(rail))
+    } catch (error) {
+      environment.reportError(error)
+      return Promise.resolve()
+    }
+    const tracked = request
+      .catch((error) => environment.reportError(error))
+      .finally(() => {
+        if (inFlight === tracked) inFlight = null
+      })
+    inFlight = tracked
+    return tracked
+  }
+
+  function start() {
+    void refreshCurrent()
+    if (started) return
+    started = true
+
+    environment.addWindowListener('focus', () => void refreshCurrent())
+    environment.addWindowListener('online', () => void refreshCurrent())
+    environment.addDocumentListener('visibilitychange', () => {
+      if (environment.isVisible()) void refreshCurrent()
+    })
+    environment.setInterval(() => void refreshCurrent(), SPOTIFY_REFRESH_INTERVAL)
+  }
+
+  return { start }
+}
+
+const browserEnvironment: SpotifySyncEnvironment = {
+  getRail: () => {
+    const rail = document.querySelector('#runtime-rail')
+    return rail && rail.getClientRects().length > 0 ? rail : null
+  },
+  isVisible: () => document.visibilityState !== 'hidden',
+  addWindowListener: (type, listener) => window.addEventListener(type, listener),
+  addDocumentListener: (type, listener) =>
+    document.addEventListener(type, listener),
+  setInterval: (callback, delay) => {
+    window.setInterval(callback, delay)
+  },
+  reportError: (error) => console.warn('[spotify-sync] refresh failed', error),
+}
+
+const browserSpotifySync = createSpotifySync(
+  refreshSpotify,
+  browserEnvironment,
+)
+
+export function syncSpotify() {
+  browserSpotifySync.start()
+}

--- a/src/components/studio/runtime-rail/client/spotify-wave.test.ts
+++ b/src/components/studio/runtime-rail/client/spotify-wave.test.ts
@@ -1,0 +1,103 @@
+// @ts-nocheck -- Bun's test globals are not part of the Astro app tsconfig.
+import { describe, expect, test } from 'bun:test'
+import {
+  createSpotifyWavePersistence,
+  type SpotifyWaveEnvironment,
+} from './spotify-wave'
+
+type Listener = () => void
+
+class FakeWaveEnvironment implements SpotifyWaveEnvironment {
+  nowValue = 0
+  animations: Animation[] = []
+  readonly listeners = new Map<string, Listener[]>()
+  readonly scheduled: Listener[] = []
+
+  getAnimations = () => this.animations
+  now = () => this.nowValue
+  schedule = (listener: Listener) => {
+    this.scheduled.push(listener)
+  }
+  addDocumentListener = (type: string, listener: Listener) => {
+    const listeners = this.listeners.get(type) ?? []
+    listeners.push(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  emit(type: 'astro:before-swap' | 'astro:after-swap') {
+    for (const listener of this.listeners.get(type) ?? []) listener()
+  }
+
+  flushScheduled() {
+    for (const listener of this.scheduled.splice(0)) listener()
+  }
+}
+
+function fakeAnimation(currentTime: number, playState = 'running') {
+  return { currentTime, playState } as Animation
+}
+
+describe('Spotify wave persistence', () => {
+  test('restores a recreated running animation at its continuous timeline', () => {
+    const environment = new FakeWaveEnvironment()
+    const original = fakeAnimation(420)
+    environment.animations = [original]
+    environment.nowValue = 1000
+    const persistence = createSpotifyWavePersistence(environment)
+
+    persistence.start()
+    environment.emit('astro:before-swap')
+
+    const recreated = fakeAnimation(0)
+    environment.animations = [recreated]
+    environment.nowValue = 1060
+    environment.emit('astro:after-swap')
+    environment.flushScheduled()
+
+    expect(recreated.currentTime).toBe(480)
+  })
+
+  test('does not overwrite an animation object that survived the route swap', () => {
+    const environment = new FakeWaveEnvironment()
+    const animation = fakeAnimation(420)
+    environment.animations = [animation]
+    const persistence = createSpotifyWavePersistence(environment)
+
+    persistence.start()
+    environment.emit('astro:before-swap')
+    animation.currentTime = 500
+    environment.emit('astro:after-swap')
+    environment.flushScheduled()
+
+    expect(animation.currentTime).toBe(500)
+  })
+
+  test('restores a paused animation without advancing it', () => {
+    const environment = new FakeWaveEnvironment()
+    environment.animations = [fakeAnimation(420, 'paused')]
+    environment.nowValue = 1000
+    const persistence = createSpotifyWavePersistence(environment)
+
+    persistence.start()
+    environment.emit('astro:before-swap')
+
+    const recreated = fakeAnimation(0, 'paused')
+    environment.animations = [recreated]
+    environment.nowValue = 1200
+    environment.emit('astro:after-swap')
+    environment.flushScheduled()
+
+    expect(recreated.currentTime).toBe(420)
+  })
+
+  test('registers route listeners only once', () => {
+    const environment = new FakeWaveEnvironment()
+    const persistence = createSpotifyWavePersistence(environment)
+
+    persistence.start()
+    persistence.start()
+
+    expect(environment.listeners.get('astro:before-swap')).toHaveLength(1)
+    expect(environment.listeners.get('astro:after-swap')).toHaveLength(1)
+  })
+})

--- a/src/components/studio/runtime-rail/client/spotify-wave.ts
+++ b/src/components/studio/runtime-rail/client/spotify-wave.ts
@@ -1,0 +1,86 @@
+type Listener = () => void
+
+type RouteSwapEvent = 'astro:before-swap' | 'astro:after-swap'
+
+interface AnimationSnapshot {
+  animation: Animation
+  currentTime: number
+  capturedAt: number
+  playState: AnimationPlayState
+}
+
+export interface SpotifyWaveEnvironment {
+  getAnimations: () => Animation[]
+  now: () => number
+  schedule: (listener: Listener) => void
+  addDocumentListener: (type: RouteSwapEvent, listener: Listener) => void
+}
+
+export function createSpotifyWavePersistence(
+  environment: SpotifyWaveEnvironment,
+) {
+  let started = false
+  let snapshots: AnimationSnapshot[] = []
+
+  function capture() {
+    const capturedAt = environment.now()
+    snapshots = environment
+      .getAnimations()
+      .flatMap((animation) =>
+        typeof animation.currentTime === 'number'
+          ? [
+              {
+                animation,
+                currentTime: animation.currentTime,
+                capturedAt,
+                playState: animation.playState,
+              },
+            ]
+          : [],
+      )
+  }
+
+  function restore() {
+    environment.schedule(() => {
+      const animations = environment.getAnimations()
+      const restoredAt = environment.now()
+
+      for (const [index, animation] of animations.entries()) {
+        const snapshot = snapshots[index]
+        if (!snapshot || animation === snapshot.animation) continue
+
+        const elapsed =
+          snapshot.playState === 'running'
+            ? restoredAt - snapshot.capturedAt
+            : 0
+        animation.currentTime = snapshot.currentTime + elapsed
+      }
+
+      snapshots = []
+    })
+  }
+
+  function start() {
+    if (started) return
+    started = true
+    environment.addDocumentListener('astro:before-swap', capture)
+    environment.addDocumentListener('astro:after-swap', restore)
+  }
+
+  return { start }
+}
+
+const browserSpotifyWavePersistence = createSpotifyWavePersistence({
+  getAnimations: () =>
+    Array.from(document.querySelectorAll<HTMLElement>('[data-spotify-eq] span'))
+      .map((bar) => bar.getAnimations()[0])
+      .filter((animation): animation is Animation => Boolean(animation)),
+  now: () => performance.now(),
+  schedule: (listener) => requestAnimationFrame(() => listener()),
+  addDocumentListener: (type, listener) =>
+    document.addEventListener(type, listener),
+})
+
+export function preserveSpotifyWave() {
+  browserSpotifyWavePersistence.start()
+}

--- a/src/components/studio/runtime-rail/client/spotify.ts
+++ b/src/components/studio/runtime-rail/client/spotify.ts
@@ -1,8 +1,6 @@
 import { fetchRuntimeJson } from './shared'
 import type { SpotifyPayload } from './types'
 
-export const SPOTIFY_REFRESH_INTERVAL = 45 * 1000
-
 function spotifyStatusLabel(status: SpotifyPayload['status']): string {
   return status || 'unavailable'
 }
@@ -92,6 +90,8 @@ function updateSpotify(rail: Element, spotify: SpotifyPayload | null) {
 }
 
 export async function refreshSpotify(rail: Element) {
-  const spotify = await fetchRuntimeJson<SpotifyPayload>('/api/spotify.json')
+  const spotify = await fetchRuntimeJson<SpotifyPayload>('/api/spotify.json', {
+    cache: 'no-store',
+  })
   updateSpotify(rail, spotify)
 }

--- a/src/lib/runtime/shared.test.ts
+++ b/src/lib/runtime/shared.test.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck -- Bun's test globals are not part of the Astro app tsconfig.
+import { expect, test } from 'bun:test'
+import { noStoreJsonHeaders } from './shared'
+
+test('noStoreJsonHeaders prevents browser and shared CDN caching', () => {
+  expect(noStoreJsonHeaders()).toEqual({
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'private, no-store, max-age=0',
+  })
+})

--- a/src/lib/runtime/shared.ts
+++ b/src/lib/runtime/shared.ts
@@ -27,3 +27,10 @@ export function jsonHeaders(ttl = 60): HeadersInit {
     'cache-control': `public, s-maxage=${ttl}, stale-while-revalidate=${ttl * 10}`,
   }
 }
+
+export function noStoreJsonHeaders(): HeadersInit {
+  return {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'private, no-store, max-age=0',
+  }
+}

--- a/src/lib/runtime/spotify.test.ts
+++ b/src/lib/runtime/spotify.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck -- Bun's test globals are not part of the Astro app tsconfig.
+import { describe, expect, test } from 'bun:test'
+import { spotifyTokenFailureMessage } from './spotify'
+
+describe('spotifyTokenFailureMessage', () => {
+  test('reports revoked authorization separately from missing credentials', async () => {
+    const response = new Response(
+      JSON.stringify({
+        error: 'invalid_grant',
+        error_description: 'Refresh token revoked',
+      }),
+      {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      },
+    )
+
+    await expect(spotifyTokenFailureMessage(response)).resolves.toBe(
+      'Spotify authorization needs to be renewed.',
+    )
+  })
+
+  test('uses a safe generic message for other token endpoint failures', async () => {
+    const response = new Response('upstream unavailable', { status: 503 })
+
+    await expect(spotifyTokenFailureMessage(response)).resolves.toBe(
+      'Spotify token refresh failed.',
+    )
+  })
+})

--- a/src/lib/runtime/spotify.ts
+++ b/src/lib/runtime/spotify.ts
@@ -21,6 +21,11 @@ interface SpotifyApiItem {
   show?: { name?: string; images?: SpotifyApiImage[] }
 }
 
+interface SpotifyAccessTokenResult {
+  accessToken?: string
+  error?: string
+}
+
 function unavailableSpotify(
   error = 'Spotify credentials are not configured.',
 ): SpotifyPayload {
@@ -60,12 +65,31 @@ function normalizeTrack(
   return undefined
 }
 
-async function getSpotifyAccessToken(): Promise<string | null> {
+export async function spotifyTokenFailureMessage(
+  response: Response,
+): Promise<string> {
+  if (response.status === 400) {
+    const data = await response
+      .clone()
+      .json()
+      .catch(() => null)
+
+    if (data?.error === 'invalid_grant') {
+      return 'Spotify authorization needs to be renewed.'
+    }
+  }
+
+  return 'Spotify token refresh failed.'
+}
+
+async function getSpotifyAccessToken(): Promise<SpotifyAccessTokenResult> {
   const clientId = env('SPOTIFY_CLIENT_ID')
   const clientSecret = env('SPOTIFY_CLIENT_SECRET')
   const refreshToken = env('SPOTIFY_REFRESH_TOKEN')
 
-  if (!clientId || !clientSecret || !refreshToken) return null
+  if (!clientId || !clientSecret || !refreshToken) {
+    return { error: 'Spotify credentials are not configured.' }
+  }
 
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
@@ -81,23 +105,27 @@ async function getSpotifyAccessToken(): Promise<string | null> {
     signal: timeoutSignal(),
   })
 
-  if (!response.ok) return null
+  if (!response.ok) {
+    return { error: await spotifyTokenFailureMessage(response) }
+  }
 
   const data = (await response.json()) as { access_token?: string }
-  return data.access_token ?? null
+  if (!data.access_token) return { error: 'Spotify token refresh failed.' }
+
+  return { accessToken: data.access_token }
 }
 
 export async function fetchSpotifyStatus(): Promise<SpotifyPayload> {
   try {
-    const accessToken = await getSpotifyAccessToken()
-    if (!accessToken) return unavailableSpotify()
+    const token = await getSpotifyAccessToken()
+    if (!token.accessToken) return unavailableSpotify(token.error)
 
     const currentUrl = new URL(CURRENTLY_PLAYING_ENDPOINT)
     currentUrl.searchParams.set('additional_types', 'track,episode')
 
     const current = await fetch(currentUrl, {
       cache: 'no-store',
-      headers: { Authorization: `Bearer ${accessToken}` },
+      headers: { Authorization: ['Bearer', token.accessToken].join(' ') },
       signal: timeoutSignal(),
     })
 
@@ -116,7 +144,7 @@ export async function fetchSpotifyStatus(): Promise<SpotifyPayload> {
 
     const recent = await fetch(RECENTLY_PLAYED_ENDPOINT, {
       cache: 'no-store',
-      headers: { Authorization: `Bearer ${accessToken}` },
+      headers: { Authorization: ['Bearer', token.accessToken].join(' ') },
       signal: timeoutSignal(),
     })
 

--- a/src/lib/runtime/spotify.ts
+++ b/src/lib/runtime/spotify.ts
@@ -69,6 +69,7 @@ async function getSpotifyAccessToken(): Promise<string | null> {
 
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
+    cache: 'no-store',
     headers: {
       Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -95,6 +96,7 @@ export async function fetchSpotifyStatus(): Promise<SpotifyPayload> {
     currentUrl.searchParams.set('additional_types', 'track,episode')
 
     const current = await fetch(currentUrl, {
+      cache: 'no-store',
       headers: { Authorization: `Bearer ${accessToken}` },
       signal: timeoutSignal(),
     })
@@ -113,6 +115,7 @@ export async function fetchSpotifyStatus(): Promise<SpotifyPayload> {
     }
 
     const recent = await fetch(RECENTLY_PLAYED_ENDPOINT, {
+      cache: 'no-store',
       headers: { Authorization: `Bearer ${accessToken}` },
       signal: timeoutSignal(),
     })

--- a/src/pages/api/spotify.json.ts
+++ b/src/pages/api/spotify.json.ts
@@ -1,10 +1,10 @@
 import type { APIRoute } from 'astro'
-import { jsonHeaders } from '~/lib/runtime/shared'
+import { noStoreJsonHeaders } from '~/lib/runtime/shared'
 import { fetchSpotifyStatus } from '~/lib/runtime/spotify'
 
 export const prerender = false
 
 export const GET: APIRoute = async () => {
   const payload = await fetchSpotifyStatus()
-  return new Response(JSON.stringify(payload), { headers: jsonHeaders(30) })
+  return new Response(JSON.stringify(payload), { headers: noStoreJsonHeaders() })
 }

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -19,14 +19,17 @@
 }
 
 .eq {
-  display: none;
+  display: inline-flex;
+  visibility: hidden;
+  opacity: 0;
   align-items: flex-end;
   gap: 2px;
   height: 14px;
 }
 
 .eq.is-playing {
-  display: inline-flex;
+  visibility: visible;
+  opacity: 1;
 }
 
 .eq span {
@@ -35,6 +38,11 @@
   border-radius: 9999px;
   background: #1db954;
   animation: eq 0.45s ease-in-out infinite alternate;
+  animation-play-state: paused;
+}
+
+.eq.is-playing span {
+  animation-play-state: running;
 }
 
 .eq span:nth-child(1) {


### PR DESCRIPTION
Fix the right-rail Spotify widget staying one state behind after track changes, pauses, reloads, and tab focus.

## What changed

- Removed the 30s CDN cache + 300s stale-while-revalidate window from `/api/spotify.json`.
- Marked browser, API, token, currently-playing, and recently-played requests as `no-store`.
- Refresh Spotify immediately on Astro page load, window focus, tab visibility restore, and reconnect.
- Poll every 15 seconds while the tab and right rail are visible.
- Deduplicate overlapping focus/navigation/interval requests and recover cleanly after refresh failures.
- Skip polling for the hidden mobile rail.
- Keep the equalizer mounted and preserve each bar's animation timeline across Astro route swaps, so a still-playing track no longer restarts the wave.
- Distinguish missing credentials, revoked authorization, and generic token-refresh failures without exposing token details.
- Replace the gist's insecure localhost redirect example with HTTPS while preserving its original quick setup and images.

## Root cause

The old 45-second poll was longer than the API's 30-second fresh TTL, so each poll could receive stale data while Vercel refreshed in the background. Unlike the v3 SWR implementation, v4 also had no focus revalidation.

## Verification

- `bun test src/lib/runtime/spotify.test.ts src/components/studio/runtime-rail/client/spotify-wave.test.ts src/components/studio/runtime-rail/client/spotify-sync.test.ts src/lib/runtime/shared.test.ts` — 11 passed.
- `bun run check` — 0 errors/warnings/hints.
- `bun run build` — passed.
- Preview API returns `Cache-Control: private, no-store, max-age=0` with a valid normalized Spotify payload.
- Browser smoke confirmed focus revalidation, one 15-second poll, correct now-playing state, and a clean console.
- Browser animation inspection confirmed Astro recreated the CSS animation object during navigation while the equalizer DOM node persisted; the new route-swap restoration carried the timeline forward instead of restarting it.
- Exact-value scan found no configured secrets in tracked files, the PR diff, or client output; no `.env` file or literal authorization credential is tracked.
- Gist cumulative diff versus `main` is five redirect-URL replacements only; all four original images and the original setup flow are preserved.
- Runtime implementation review: two passes, no blockers.
