### PR TITLE
chore: release v2026.7.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2026.7.22
 
 - [feature] Installable mobile app (PWA): new "Mobile app (PWA)" theme settings group (off by default). When enabled, serves a merchant-branded `/manifest.webmanifest` (name, icon, colors from theme settings with Shopify brand fallbacks), adds install head tags, registers a minimal service worker (hashed assets + CDN images only — never HTML/cart/checkout), and shows a dismissible iOS Add-to-Home-Screen hint.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.6.24",
+  "version": "2026.7.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@weaverse/pilot",
-      "version": "2026.6.24",
+      "version": "2026.7.22",
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/cabin": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weaverse/pilot",
-  "version": "2026.6.24",
+  "version": "2026.7.22",
   "description": "A production-ready Shopify storefront built with Hydrogen and Weaverse",
   "keywords": [
     "shopify",


### PR DESCRIPTION
Release v2026.7.22 — installable mobile app (PWA) driven by theme settings (#450). Version bump + lockfile regen + changelog.