### PR TITLE
Fix cart-note clearing and remove dormant analytics sender

### DIFF
--- a/app/components/cart/cart-summary-actions.tsx
+++ b/app/components/cart/cart-summary-actions.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { CartForm } from "@shopify/hydrogen";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useFetcher } from "react-router";
 import type { CartApiQueryFragment } from "storefront-api.generated";
 import { Banner } from "~/components/banner";
@@ -8,6 +8,7 @@ import { Button } from "~/components/button";
 import { Icon } from "~/components/icon";
 import { ShopifyInboxOverlayGuard } from "~/components/shopify-inbox";
 import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
+import { getSuccessfulCartNote } from "~/utils/cart-note";
 import { cn } from "~/utils/cn";
 import { useCartFetcherSync } from "./store";
 
@@ -15,31 +16,43 @@ export function NoteDialog({ cartNote: currentNote }: { cartNote: string }) {
   const [note, setNote] = useState(currentNote);
   const [submitted, setSubmitted] = useState(false);
   const fetcher = useFetcher();
+  const lastProcessedData = useRef(fetcher.data);
   useCartFetcherSync(fetcher);
   const cartRoute = usePrefixPathWithLocale("/cart");
 
   useEffect(() => {
-    if (fetcher.state === "idle" && fetcher.data) {
-      setSubmitted(true);
+    if (
+      fetcher.state !== "idle" ||
+      !fetcher.data ||
+      fetcher.data === lastProcessedData.current
+    ) {
+      return;
     }
-  }, [fetcher]);
+    lastProcessedData.current = fetcher.data;
+    const updatedNote = getSuccessfulCartNote(fetcher.data);
+    if (updatedNote === undefined) {
+      setSubmitted(false);
+      return;
+    }
+    setNote(updatedNote);
+    setSubmitted(true);
+  }, [fetcher.data, fetcher.state]);
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
     const formCartNote = formData.get("cartNote") as string;
-    if (formCartNote) {
-      fetcher.submit(
-        {
-          [CartForm.INPUT_NAME]: JSON.stringify({
-            action: CartForm.ACTIONS.NoteUpdate,
-            inputs: { cartNote: formCartNote },
-          }),
-        },
-        { method: "POST", action: cartRoute },
-      );
-      setNote(formCartNote);
-    }
+    setSubmitted(false);
+    fetcher.submit(
+      {
+        [CartForm.INPUT_NAME]: JSON.stringify({
+          action: CartForm.ACTIONS.NoteUpdate,
+          inputs: { cartNote: formCartNote },
+        }),
+      },
+      { method: "POST", action: cartRoute },
+    );
+    setNote(formCartNote);
   }
 
   return (

--- a/app/components/cart/store.ts
+++ b/app/components/cart/store.ts
@@ -11,6 +11,7 @@ import type { CartApiQueryFragment } from "storefront-api.generated";
 import { create } from "zustand";
 import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import type { loader as apiCartLoader } from "~/routes/api/cart";
+import { hasCartResponseErrors } from "~/utils/cart-note";
 
 type CartStore = {
   isOpen: boolean;
@@ -261,7 +262,12 @@ export function useCartFetcherSync(fetcher: Fetcher<unknown>) {
   const lastSyncedRef = useRef<string | null>(null);
   const fetcherData = fetcher.data as Record<string, unknown> | undefined;
   const cart = fetcherData?.cart as CartApiQueryFragment | undefined;
-  if (fetcher.state === "idle" && cart?.id && cart?.lines) {
+  if (
+    fetcher.state === "idle" &&
+    !hasCartResponseErrors(fetcherData) &&
+    cart?.id &&
+    cart?.lines
+  ) {
     const updatedAt = cart.updatedAt;
     if (updatedAt !== lastSyncedRef.current) {
       lastSyncedRef.current = updatedAt;
@@ -324,6 +330,9 @@ export function useCart(): CartWithOptimistic | null {
       continue;
     }
     const fetcherData = fetcher.data as Record<string, unknown> | undefined;
+    if (hasCartResponseErrors(fetcherData)) {
+      continue;
+    }
     const cart = fetcherData?.cart as CartApiQueryFragment | undefined;
     if (!cart?.id || !cart?.lines) {
       continue;

--- a/app/components/product/add-to-cart-button.tsx
+++ b/app/components/product/add-to-cart-button.tsx
@@ -1,39 +1,31 @@
-import type {
-  OptimisticCartLineInput,
-  ShopifyAddToCartPayload,
-  ShopifyPageViewPayload,
-} from "@shopify/hydrogen";
-import {
-  AnalyticsEventName,
-  CartForm,
-  getClientBrowserParameters,
-  sendShopifyAnalytics,
-} from "@shopify/hydrogen";
+import { CartForm, type OptimisticCartLineInput } from "@shopify/hydrogen";
 import { useEffect, useRef } from "react";
 import type { FetcherWithComponents } from "react-router";
-import { useMatches } from "react-router";
-import { Button } from "~/components/button";
+import { Button, type ButtonProps } from "~/components/button";
 import { useCartFetcherSync, useCartStore } from "~/components/cart/store";
 import { Spinner } from "~/components/spinner";
 import { usePrefixPathWithLocale } from "~/hooks/use-prefix-path-with-locale";
 import { cn } from "~/utils/cn";
-import { DEFAULT_LOCALE } from "~/utils/const";
+
+type AddToCartButtonProps = Omit<
+  ButtonProps,
+  "children" | "loading" | "type"
+> & {
+  children: React.ReactNode;
+  lines: OptimisticCartLineInput[];
+};
+
+type AddToCartButtonContentProps = Omit<AddToCartButtonProps, "lines"> & {
+  fetcher: FetcherWithComponents<any>;
+};
 
 export function AddToCartButton({
   children,
   lines,
   className = "",
   disabled,
-  analytics,
   ...props
-}: {
-  children: React.ReactNode;
-  lines: OptimisticCartLineInput[];
-  className?: string;
-  disabled?: boolean;
-  analytics?: unknown;
-  [key: string]: any;
-}) {
+}: AddToCartButtonProps) {
   const cartRoute = usePrefixPathWithLocale("/cart");
 
   return (
@@ -47,7 +39,6 @@ export function AddToCartButton({
           fetcher={fetcher}
           disabled={disabled}
           className={className}
-          analytics={analytics}
           {...props}
         >
           {children}
@@ -62,16 +53,8 @@ function AddToCartButtonContent({
   children,
   disabled,
   className,
-  analytics,
   ...props
-}: {
-  fetcher: FetcherWithComponents<any>;
-  children: React.ReactNode;
-  disabled?: boolean;
-  className?: string;
-  analytics?: unknown;
-  [key: string]: any;
-}) {
+}: AddToCartButtonContentProps) {
   const { open: openCartDrawer } = useCartStore();
   useCartFetcherSync(fetcher);
   const prevStateRef = useRef<"idle" | "submitting" | "loading">("idle");
@@ -85,90 +68,16 @@ function AddToCartButtonContent({
   }, [fetcher.state, openCartDrawer]);
 
   return (
-    <AddToCartAnalytics fetcher={fetcher}>
-      <input type="hidden" name="analytics" value={JSON.stringify(analytics)} />
-      <Button
-        type="submit"
-        className={cn("relative w-full", className)}
-        disabled={disabled ?? isLoading}
-        {...props}
-      >
-        <span className={cn(isLoading && "invisible")}>
-          {children || "Add to cart"}
-        </span>
-        {isLoading && <Spinner className="z-0" size={20} duration={400} />}
-      </Button>
-    </AddToCartAnalytics>
+    <Button
+      type="submit"
+      className={cn("relative w-full", className)}
+      disabled={disabled ?? isLoading}
+      {...props}
+    >
+      <span className={cn(isLoading && "invisible")}>
+        {children || "Add to cart"}
+      </span>
+      {isLoading && <Spinner className="z-0" size={20} duration={400} />}
+    </Button>
   );
-}
-
-function usePageAnalytics({ hasUserConsent }: { hasUserConsent: boolean }) {
-  const matches = useMatches();
-
-  const data: Record<string, unknown> = {};
-  for (const match of matches) {
-    const eventData = match?.data as Record<string, unknown>;
-    if (eventData) {
-      if (eventData.analytics) {
-        Object.assign(data, eventData.analytics);
-      }
-      const selectedLocale =
-        (eventData.selectedLocale as typeof DEFAULT_LOCALE) || DEFAULT_LOCALE;
-      Object.assign(data, {
-        currency: selectedLocale.currency,
-        acceptedLanguage: selectedLocale.language,
-      });
-    }
-  }
-
-  return {
-    ...data,
-    hasUserConsent,
-  } as unknown as ShopifyPageViewPayload;
-}
-
-function AddToCartAnalytics({
-  fetcher,
-  children,
-}: {
-  fetcher: FetcherWithComponents<any>;
-  children: React.ReactNode;
-}) {
-  const fetcherData = fetcher.data;
-  const formData = fetcher.formData;
-  const pageAnalytics = usePageAnalytics({ hasUserConsent: true });
-
-  useEffect(() => {
-    if (formData) {
-      const cartData: Record<string, unknown> = {};
-      const cartInputs = CartForm.getFormInput(formData);
-
-      try {
-        if (cartInputs.inputs.analytics) {
-          const dataInForm: unknown = JSON.parse(
-            String(cartInputs.inputs.analytics),
-          );
-          Object.assign(cartData, dataInForm);
-        }
-      } catch {
-        // do nothing
-      }
-
-      if (Object.keys(cartData).length && fetcherData) {
-        const addToCartPayload: ShopifyAddToCartPayload = {
-          ...getClientBrowserParameters(),
-          ...pageAnalytics,
-          ...cartData,
-          cartId: fetcherData.cart.id,
-        };
-
-        sendShopifyAnalytics({
-          eventName: AnalyticsEventName.ADD_TO_CART,
-          payload: addToCartPayload,
-        });
-      }
-    }
-  }, [fetcherData, formData, pageAnalytics]);
-
-  return <>{children}</>;
 }

--- a/app/routes/cart/cart-page.tsx
+++ b/app/routes/cart/cart-page.tsx
@@ -28,6 +28,11 @@ import {
 import { ProductCard } from "~/components/product-card";
 import { Section } from "~/components/section";
 import { Swimlane } from "~/components/swimlane";
+import {
+  getInvalidCartNoteResult,
+  isCartNoteInput,
+  updateCartNote,
+} from "~/utils/cart-note";
 import { COUNTRIES, getLocalePrefixFromPath } from "~/utils/const";
 import { getFeaturedProducts } from "~/utils/featured-products";
 
@@ -84,11 +89,12 @@ export async function action({ request, context }: ActionFunctionArgs) {
       break;
     }
     case CartForm.ACTIONS.NoteUpdate: {
-      const cartOptions = await syncCartBuyerIdentityToLocale();
-      const cartNote = inputs.cartNote as string;
-      if (cartNote) {
-        result = await cart.updateNote(cartNote, cartOptions);
+      const cartNote = inputs.cartNote;
+      if (!isCartNoteInput(cartNote)) {
+        return data(getInvalidCartNoteResult(), { status: 400 });
       }
+      const cartOptions = await syncCartBuyerIdentityToLocale();
+      result = await updateCartNote(cart, cartNote, cartOptions);
       break;
     }
     case CartForm.ACTIONS.DiscountCodesUpdate: {

--- a/app/utils/cart-note.ts
+++ b/app/utils/cart-note.ts
@@ -1,0 +1,100 @@
+interface CartNoteUpdater<TOptions, TResult> {
+  updateNote(note: string, options?: TOptions): Promise<TResult>;
+}
+
+interface CartNoteResult {
+  cart?: {
+    id?: unknown;
+    note?: unknown;
+  };
+}
+
+interface CartNoteUserError {
+  field: string[];
+  message: string;
+}
+
+export interface InvalidCartNoteResult {
+  cart: undefined;
+  errors: undefined;
+  userErrors: CartNoteUserError[];
+}
+
+export function isCartNoteInput(note: unknown): note is string {
+  return typeof note === "string";
+}
+
+export function getInvalidCartNoteResult(): InvalidCartNoteResult {
+  return {
+    cart: undefined,
+    errors: undefined,
+    userErrors: [
+      {
+        field: ["cartNote"],
+        message: "Cart note must be a string.",
+      },
+    ],
+  };
+}
+
+export function normalizeCartNote(note: string): string {
+  return note.trim() ? note : "";
+}
+
+export function updateCartNote<TOptions, TResult>(
+  cart: CartNoteUpdater<TOptions, TResult>,
+  note: string,
+  options?: TOptions,
+): Promise<TResult>;
+export function updateCartNote<TOptions, TResult>(
+  cart: CartNoteUpdater<TOptions, TResult>,
+  note: unknown,
+  options?: TOptions,
+): Promise<TResult | InvalidCartNoteResult>;
+export async function updateCartNote<TOptions, TResult>(
+  cart: CartNoteUpdater<TOptions, TResult>,
+  note: unknown,
+  options?: TOptions,
+): Promise<TResult | InvalidCartNoteResult> {
+  if (!isCartNoteInput(note)) {
+    return getInvalidCartNoteResult();
+  }
+  return cart.updateNote(normalizeCartNote(note), options);
+}
+
+export function hasCartResponseErrors(data: unknown): boolean {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  let { errors, userErrors } = data as {
+    errors?: unknown;
+    userErrors?: unknown;
+  };
+  return hasErrors(errors) || hasErrors(userErrors);
+}
+
+export function getSuccessfulCartNote(data: unknown): string | undefined {
+  if (!data || typeof data !== "object" || hasCartResponseErrors(data)) {
+    return;
+  }
+
+  let { cart } = data as CartNoteResult;
+  if (!cart || typeof cart.id !== "string" || !cart.id) {
+    return;
+  }
+  if (cart.note === null) {
+    return "";
+  }
+  if (typeof cart.note !== "string") {
+    return;
+  }
+  return cart.note;
+}
+
+function hasErrors(errors: unknown): boolean {
+  if (Array.isArray(errors)) {
+    return errors.length > 0;
+  }
+  return Boolean(errors);
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev:ca": "shopify hydrogen dev --codegen --port 3456 --customer-account-push",
     "preview": "shopify hydrogen preview --build",
     "start": "shopify hydrogen preview",
+    "test:cart-correctness": "node --experimental-strip-types --test tests/cart-correctness.node.mjs",
     "typecheck": "tsc --noEmit",
     "routes-check": "shopify hydrogen check routes",
     "codegen": "shopify hydrogen codegen",

--- a/tests/cart-correctness.node.mjs
+++ b/tests/cart-correctness.node.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, test } from "node:test";
+import {
+  getInvalidCartNoteResult,
+  getSuccessfulCartNote,
+  hasCartResponseErrors,
+  normalizeCartNote,
+  updateCartNote,
+} from "../app/utils/cart-note.ts";
+
+const PROJECT_ROOT = new URL("../", import.meta.url);
+const ADD_TO_CART_SURFACES = [
+  "app/components/product-card/quick-shop.tsx",
+  "app/sections/main-product/buy-buttons/index.tsx",
+  "app/sections/main-product/buy-buttons/sticky-atc-bar.tsx",
+  "app/sections/single-product/index.tsx",
+];
+const MALFORMED_CART_NOTES = [
+  ["missing", undefined],
+  ["null", null],
+  ["numeric", 42],
+  ["array", ["note"]],
+  ["object", { note: "note" }],
+  ["boolean", true],
+];
+
+describe("cart note updates", () => {
+  test("normalizes only an all-whitespace note to the empty string", () => {
+    assert.equal(normalizeCartNote(""), "");
+    assert.equal(normalizeCartNote(" \n\t "), "");
+    assert.equal(normalizeCartNote("  Gift note  "), "  Gift note  ");
+  });
+
+  test("sends the normalized note and cart options to Hydrogen", async () => {
+    const calls = [];
+    const cart = {
+      async updateNote(note, cartOptions) {
+        calls.push({ note, options: cartOptions });
+        return { cart: { id: "gid://shopify/Cart/1", note } };
+      },
+    };
+    const options = { cartId: "gid://shopify/Cart/1" };
+
+    await updateCartNote(cart, "Added note", options);
+    await updateCartNote(cart, "Replacement note", options);
+    await updateCartNote(cart, " \n\t ", options);
+
+    assert.deepEqual(calls, [
+      { note: "Added note", options },
+      { note: "Replacement note", options },
+      { note: "", options },
+    ]);
+  });
+
+  for (const [name, note] of MALFORMED_CART_NOTES) {
+    test(`returns a controlled response for ${name} input`, async () => {
+      let calls = 0;
+      const cart = {
+        async updateNote() {
+          calls += 1;
+          return { cart: { id: "gid://shopify/Cart/1" } };
+        },
+      };
+
+      assert.deepEqual(
+        await updateCartNote(cart, note),
+        getInvalidCartNoteResult(),
+      );
+      assert.equal(calls, 0);
+    });
+  }
+
+  test("accepts only an error-free authoritative cart note", () => {
+    assert.equal(
+      getSuccessfulCartNote({
+        cart: { id: "gid://shopify/Cart/1", note: "Added note" },
+        errors: [],
+        userErrors: [],
+      }),
+      "Added note",
+    );
+    assert.equal(
+      getSuccessfulCartNote({
+        cart: { id: "gid://shopify/Cart/1", note: "Replacement note" },
+      }),
+      "Replacement note",
+    );
+    assert.equal(
+      getSuccessfulCartNote({
+        cart: { id: "gid://shopify/Cart/1", note: null },
+      }),
+      "",
+    );
+  });
+
+  test("rejects user errors, GraphQL errors, network failure, and missing cart data", () => {
+    assert.equal(
+      getSuccessfulCartNote({
+        cart: { id: "gid://shopify/Cart/1", note: "Not saved" },
+        userErrors: [{ message: "Rejected" }],
+      }),
+      undefined,
+    );
+    assert.equal(
+      getSuccessfulCartNote({
+        cart: { id: "gid://shopify/Cart/1", note: "Not saved" },
+        errors: [{ message: "GraphQL failed" }],
+      }),
+      undefined,
+    );
+    assert.equal(getSuccessfulCartNote(undefined), undefined);
+    assert.equal(getSuccessfulCartNote({ userErrors: [] }), undefined);
+    assert.equal(
+      getSuccessfulCartNote({ cart: { id: "gid://shopify/Cart/1" } }),
+      undefined,
+    );
+  });
+
+  test("a successful retry is accepted after a failed response", () => {
+    const failed = {
+      cart: { id: "gid://shopify/Cart/1", note: "Old note" },
+      userErrors: [{ message: "Try again" }],
+    };
+    const retried = {
+      cart: { id: "gid://shopify/Cart/1", note: "Retried note" },
+      userErrors: [],
+    };
+
+    assert.equal(getSuccessfulCartNote(failed), undefined);
+    assert.equal(getSuccessfulCartNote(retried), "Retried note");
+  });
+});
+
+describe("cart response error gating", () => {
+  test("accepts responses without errors", () => {
+    assert.equal(hasCartResponseErrors(undefined), false);
+    assert.equal(hasCartResponseErrors({}), false);
+    assert.equal(hasCartResponseErrors({ errors: [], userErrors: [] }), false);
+  });
+
+  test("rejects GraphQL and user error responses", () => {
+    assert.equal(
+      hasCartResponseErrors({ errors: [{ message: "GraphQL failed" }] }),
+      true,
+    );
+    assert.equal(
+      hasCartResponseErrors({ userErrors: [{ message: "Rejected" }] }),
+      true,
+    );
+  });
+
+  test("both cart-store fetcher paths use the shared error gate", async () => {
+    const source = await readFile(
+      new URL("app/components/cart/store.ts", PROJECT_ROOT),
+      "utf8",
+    );
+    assert.equal(
+      source.match(/hasCartResponseErrors\(fetcherData\)/g)?.length,
+      2,
+    );
+  });
+});
+
+describe("add-to-cart analytics ownership", () => {
+  test("all four add-to-cart surfaces use the shared button without an analytics prop", async () => {
+    for (const file of ADD_TO_CART_SURFACES) {
+      const source = await readFile(new URL(file, PROJECT_ROOT), "utf8");
+      assert.match(source, /<AddToCartButton\b/);
+      assert.doesNotMatch(
+        source,
+        /<AddToCartButton\b[\s\S]*?\banalytics\s*=/,
+        `${file} must not activate a direct analytics sender`,
+      );
+    }
+  });
+
+  test("the shared button has no direct Shopify analytics sender", async () => {
+    const source = await readFile(
+      new URL("app/components/product/add-to-cart-button.tsx", PROJECT_ROOT),
+      "utf8",
+    );
+
+    assert.doesNotMatch(
+      source,
+      /sendShopifyAnalytics|hasUserConsent|AddToCartAnalytics|name="analytics"|analytics\?:|\[key:\s*string\]:\s*any/,
+    );
+    assert.match(source, /Omit<\s*ButtonProps,/);
+  });
+
+  test("Hydrogen Analytics.Provider remains the canonical owner", async () => {
+    const source = await readFile(
+      new URL("app/root.tsx", PROJECT_ROOT),
+      "utf8",
+    );
+    assert.match(source, /<Analytics\.Provider\b/);
+  });
+});


### PR DESCRIPTION
## Summary

- allow buyers to clear cart notes while preserving nonblank whitespace and rejecting malformed note inputs with a controlled HTTP 400 response
- show note success only from an authoritative error-free cart response, and reject errored mutation carts from both canonical reconciliation paths
- delete the unused direct add-to-cart analytics sender and hard-coded consent value, leaving Hydrogen `Analytics.Provider` as the sole owner
- tighten `AddToCartButton` props so a dormant `analytics` payload cannot be reintroduced accidentally
- register focused cart-correctness tests

## Scope decision

#459 originally described a broader consent and analytics matrix. The audited direct sender had no callers, so the smallest safe resolution is deletion rather than building another sender or consent abstraction. Provider-derived analytics remain, and cart responses containing GraphQL or user errors no longer enter canonical cart state.

No Standard Storefront Actions/Events adapter or compatibility runtime is included.

## Verification

- `npm run test:cart-correctness` — 17/17 passed
- `npm run typecheck` — passed
- `npm run routes-check` — passed
- `npm run biome` — passed with three pre-existing warnings
- `npm run build` — passed with existing nonfatal bundle-analyzer warnings
- `git diff --check` — passed
- independent pre-commit review — passed after two blocker fixes

No live cart, checkout, payment, purchase, deployment, or production-data operation was performed.

## Residual risk

Pilot has no safe mocked component/browser harness. Focused tests cover the mutation boundary helpers, authoritative success extraction, error gating, all four current add-to-cart call sites, and analytics ownership. Browser interaction remains covered by the existing application behavior rather than a new test framework.

Closes #458
Closes #459
