### PR TITLE
Fix mobile studio navigation

### DIFF
--- a/src/components/icons/HugeIcon.astro
+++ b/src/components/icons/HugeIcon.astro
@@ -29,6 +29,7 @@ import {
   RobotIcon,
   Rocket01Icon,
   ShoppingBag01Icon,
+  SidebarLeftIcon,
   StarIcon,
   Store01Icon,
   Tag01Icon,
@@ -67,6 +68,7 @@ type IconName =
   | 'robot'
   | 'rocket'
   | 'shopping-bag'
+  | 'sidebar-left'
   | 'star'
   | 'store'
   | 'tag'
@@ -120,6 +122,7 @@ const ICONS = {
   robot: RobotIcon,
   rocket: Rocket01Icon,
   'shopping-bag': ShoppingBag01Icon,
+  'sidebar-left': SidebarLeftIcon,
   star: StarIcon,
   store: Store01Icon,
   tag: Tag01Icon,

--- a/src/components/icons/HugeIcon.astro
+++ b/src/components/icons/HugeIcon.astro
@@ -30,6 +30,7 @@ import {
   Rocket01Icon,
   ShoppingBag01Icon,
   SidebarLeftIcon,
+  SidebarRightIcon,
   StarIcon,
   Store01Icon,
   Tag01Icon,
@@ -69,6 +70,7 @@ type IconName =
   | 'rocket'
   | 'shopping-bag'
   | 'sidebar-left'
+  | 'sidebar-right'
   | 'star'
   | 'store'
   | 'tag'
@@ -123,6 +125,7 @@ const ICONS = {
   rocket: Rocket01Icon,
   'shopping-bag': ShoppingBag01Icon,
   'sidebar-left': SidebarLeftIcon,
+  'sidebar-right': SidebarRightIcon,
   star: StarIcon,
   store: Store01Icon,
   tag: Tag01Icon,

--- a/src/components/studio/StudioShell.astro
+++ b/src/components/studio/StudioShell.astro
@@ -99,6 +99,7 @@ const { lastCommit, lastCommitDate, lastCommitUrl } = getCommitInfo()
       <div
         class="thin-scrollbar min-h-0 flex-1 overflow-y-auto px-[clamp(22px,5vw,78px)] pt-9.5 pb-17.5"
         data-track-region="content"
+        data-mobile-panel-background
       >
         <div class="mb-4.5 font-mono text-xs text-slate-500">{crumb}</div>
         <slot />

--- a/src/components/studio/StudioShell.astro
+++ b/src/components/studio/StudioShell.astro
@@ -81,8 +81,8 @@ const seedTabs = getSeedTabs(readmeTab, currentTab)
 const { lastCommit, lastCommitDate, lastCommitUrl } = getCommitInfo()
 ---
 
-<div id={shellId} class="studio-shell grid h-screen grid-rows-[1fr_32px] overflow-hidden bg-bg" data-rail="visible">
-  <div class="studio-workspace grid min-h-0 grid-cols-1 overflow-hidden lg:grid-cols-[260px_minmax(0,1fr)_360px]">
+<div id={shellId} class="studio-shell grid h-screen h-dvh grid-rows-[1fr_32px] overflow-hidden bg-bg" data-rail="visible">
+  <div class="studio-workspace relative grid min-h-0 grid-cols-1 overflow-hidden lg:grid-cols-[260px_minmax(0,1fr)_360px]">
     <Sidebar
       explorerItems={explorerItems}
       currentPath={currentPath}
@@ -106,6 +106,11 @@ const { lastCommit, lastCommitDate, lastCommitUrl } = getCommitInfo()
     </main>
 
     <RuntimeRail />
+    <div
+      class="studio-mobile-panel-backdrop lg:hidden"
+      data-mobile-panel-backdrop
+      aria-hidden="true"
+    ></div>
   </div>
 
   <StatusBar

--- a/src/components/studio/runtime-rail/RuntimeRail.astro
+++ b/src/components/studio/runtime-rail/RuntimeRail.astro
@@ -5,7 +5,14 @@ import SpotifyCard from './SpotifyCard.astro'
 import TokenBurnCard from './TokenBurnCard.astro'
 ---
 
-<aside id="runtime-rail" transition:persist="runtime-rail" class="runtime-rail thin-scrollbar hidden min-h-0 content-start gap-3 overflow-y-auto border-l border-line bg-panel2 p-3.5 lg:grid" data-track-region="rail">
+<aside
+  id="runtime-rail"
+  transition:persist="runtime-rail"
+  class="runtime-rail studio-mobile-panel studio-mobile-panel--right thin-scrollbar min-h-0 content-start gap-3 overflow-y-auto border-l border-line bg-panel2 p-3.5 lg:grid"
+  data-track-region="rail"
+  data-mobile-panel-name="rail"
+  aria-label="Runtime activity"
+>
   <SpotifyCard />
   <GitGrassCard />
   <TokenBurnCard />

--- a/src/components/studio/studio-shell/Sidebar.astro
+++ b/src/components/studio/studio-shell/Sidebar.astro
@@ -18,7 +18,13 @@ const { explorerItems, currentPath, dotfilesTree, activeDotfile } = Astro.props
 const isExternal = (href: string) => href.startsWith('http')
 ---
 
-<aside class="thin-scrollbar hidden min-h-0 overflow-y-auto border-r border-line bg-[#f8fafc] px-3 py-3 lg:block" data-track-region="sidebar">
+<aside
+  id="studio-sidebar"
+  class="studio-mobile-panel studio-mobile-panel--left thin-scrollbar min-h-0 overflow-y-auto border-r border-line bg-[#f8fafc] px-3 py-3 lg:block"
+  data-track-region="sidebar"
+  data-mobile-panel-name="sidebar"
+  aria-label="Site explorer"
+>
   <a href="/" class="mb-4 flex items-center gap-2.5 font-extrabold no-underline text-ink">
     <span class="flex h-9 w-9 items-center justify-center rounded-xl border border-ink bg-white font-mono text-base shadow-[3px_3px_0_var(--color-ink)]">~/</span>
     <span>leohuynh.dev</span>

--- a/src/components/studio/studio-shell/StatusBar.astro
+++ b/src/components/studio/studio-shell/StatusBar.astro
@@ -13,7 +13,11 @@ const { lastCommit, lastCommitDate, lastCommitUrl } = Astro.props
 const repoName = new URL(SITE.siteRepo).pathname.replace(/^\/+|\/+$/g, '')
 ---
 
-<footer class="studio-statusbar flex min-w-0 items-center justify-between gap-2 border-t border-line bg-white px-3 font-mono text-[12px] text-slate-600" data-track-region="bottombar">
+<footer
+  class="studio-statusbar flex min-w-0 items-center justify-between gap-2 border-t border-line bg-white px-3 font-mono text-[12px] text-slate-600"
+  data-track-region="bottombar"
+  data-mobile-panel-background
+>
   <div class="min-w-0">
     <StatusRepository
       client:visible

--- a/src/components/studio/studio-shell/TabBar.astro
+++ b/src/components/studio/studio-shell/TabBar.astro
@@ -26,6 +26,7 @@ const { seedTabs, currentTab } = Astro.props
   </button>
   <div
     class="thin-scrollbar flex min-w-0 flex-1 overflow-x-auto"
+    data-mobile-panel-background
     data-tab-bar
     data-current-href={currentTab.href}
   >

--- a/src/components/studio/studio-shell/TabBar.astro
+++ b/src/components/studio/studio-shell/TabBar.astro
@@ -11,7 +11,19 @@ interface Props {
 const { seedTabs, currentTab } = Astro.props
 ---
 
-<nav class="flex shrink-0 items-stretch border-b border-line bg-[#fbfcff]" data-track-region="topbar">
+<nav class="flex min-h-11 shrink-0 items-stretch border-b border-line bg-[#fbfcff] lg:min-h-0" data-track-region="topbar">
+  <button
+    type="button"
+    class="studio-mobile-panel-toggle relative z-50 grid min-w-11 shrink-0 cursor-pointer place-items-center border-r border-line bg-[#fbfcff] px-3 text-muted hover:bg-white hover:text-slate-950 lg:hidden"
+    data-toggle-mobile-panel="sidebar"
+    data-open-label="Open site explorer"
+    data-close-label="Close site explorer"
+    aria-controls="studio-sidebar"
+    aria-expanded="false"
+    aria-label="Open site explorer"
+  >
+    <HugeIcon name="sidebar-left" size={18} />
+  </button>
   <div
     class="thin-scrollbar flex min-w-0 flex-1 overflow-x-auto"
     data-tab-bar

--- a/src/components/studio/studio-shell/TabBar.astro
+++ b/src/components/studio/studio-shell/TabBar.astro
@@ -53,6 +53,18 @@ const { seedTabs, currentTab } = Astro.props
   </div>
   <button
     type="button"
+    class="studio-mobile-panel-toggle relative z-50 grid min-w-11 shrink-0 cursor-pointer place-items-center border-l border-line bg-[#fbfcff] px-3 text-muted hover:bg-white hover:text-slate-950 lg:hidden"
+    data-toggle-mobile-panel="rail"
+    data-open-label="Open runtime activity"
+    data-close-label="Close runtime activity"
+    aria-controls="runtime-rail"
+    aria-expanded="false"
+    aria-label="Open runtime activity"
+  >
+    <HugeIcon name="sidebar-right" size={18} />
+  </button>
+  <button
+    type="button"
     class="hidden cursor-pointer shrink-0 border-l border-line bg-[#fbfcff] px-3.5 py-2.5 font-mono text-xs text-muted hover:bg-white hover:text-slate-950 lg:block"
     data-toggle-rail
     aria-controls="runtime-rail"

--- a/src/components/studio/studio-shell/TabBar.astro
+++ b/src/components/studio/studio-shell/TabBar.astro
@@ -11,7 +11,7 @@ interface Props {
 const { seedTabs, currentTab } = Astro.props
 ---
 
-<nav class="flex min-h-11 shrink-0 items-stretch border-b border-line bg-[#fbfcff] lg:min-h-0" data-track-region="topbar">
+<nav class="studio-topbar flex min-h-11 shrink-0 items-stretch border-b border-line bg-[#fbfcff] lg:min-h-0" data-track-region="topbar">
   <button
     type="button"
     class="studio-mobile-panel-toggle relative z-50 grid min-w-11 shrink-0 cursor-pointer place-items-center border-r border-line bg-[#fbfcff] px-3 text-muted hover:bg-white hover:text-slate-950 lg:hidden"

--- a/src/components/studio/studio-shell/client/boot.ts
+++ b/src/components/studio/studio-shell/client/boot.ts
@@ -1,6 +1,7 @@
 import './globals'
 import { setupClock, setupCommitAgo } from './clock'
 import { bindVersionMenu, setupFolders, setupRail } from './interactions'
+import { setupMobilePanels } from './mobile-panels'
 import { setupNavPending } from './nav-pending'
 import { initStudioTabs } from './tabs'
 
@@ -17,6 +18,7 @@ function initStudioShell() {
   document.querySelectorAll<HTMLElement>('.studio-shell').forEach((shell) => {
     initStudioTabs(shell)
     setupRail(shell, root)
+    setupMobilePanels(shell)
     setupFolders(shell)
     setupClock(shell)
     setupCommitAgo(shell)

--- a/src/components/studio/studio-shell/client/globals.ts
+++ b/src/components/studio/studio-shell/client/globals.ts
@@ -10,5 +10,9 @@ declare global {
     __leohuynhVersionMenuBound?: boolean
     // Guards the document-level nav-pending transition listeners to bind only once.
     __leohuynhNavPendingBound?: boolean
+    // Guards delegated mobile-panel and viewport listeners to bind only once.
+    __leohuynhMobilePanelsBound?: boolean
+    // Returns focus to the control that opened the active mobile panel.
+    __leohuynhMobilePanelTrigger?: HTMLElement
   }
 }

--- a/src/components/studio/studio-shell/client/interactions.ts
+++ b/src/components/studio/studio-shell/client/interactions.ts
@@ -2,21 +2,21 @@
 // the click-driven UI bits of the shell. Folder + rail state live on `window`
 // / localStorage so they survive SPA navigation.
 
+export function closeVersionMenus() {
+  document
+    .querySelectorAll<HTMLElement>('[data-version-popover]')
+    .forEach((popover) => {
+      popover.hidden = true
+    })
+  document.querySelectorAll('[data-version-trigger]').forEach((trigger) => {
+    trigger.setAttribute('aria-expanded', 'false')
+  })
+}
+
 /** Document-level listeners for the footer version menu. Binds only once. */
 export function bindVersionMenu() {
   if (window.__leohuynhVersionMenuBound) return
   window.__leohuynhVersionMenuBound = true
-
-  const closeVersionMenus = () => {
-    document
-      .querySelectorAll<HTMLElement>('[data-version-popover]')
-      .forEach((p) => {
-        p.hidden = true
-      })
-    document.querySelectorAll('[data-version-trigger]').forEach((t) => {
-      t.setAttribute('aria-expanded', 'false')
-    })
-  }
 
   document.addEventListener('click', (event) => {
     const target = event.target as HTMLElement

--- a/src/components/studio/studio-shell/client/mobile-panels.test.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.test.ts
@@ -1,0 +1,22 @@
+// @ts-nocheck -- Bun's test globals are not part of the Astro app tsconfig.
+import { describe, expect, test } from 'bun:test'
+
+const tabBarSource = await Bun.file(
+  new URL('../TabBar.astro', import.meta.url),
+).text()
+const sidebarSource = await Bun.file(
+  new URL('../Sidebar.astro', import.meta.url),
+).text()
+const shellSource = await Bun.file(
+  new URL('../../StudioShell.astro', import.meta.url),
+).text()
+
+describe('mobile studio navigation', () => {
+  test('exposes the existing explorer as a mobile panel', () => {
+    expect(tabBarSource).toContain('data-toggle-mobile-panel="sidebar"')
+    expect(tabBarSource).toContain('aria-controls="studio-sidebar"')
+    expect(sidebarSource).toContain('id="studio-sidebar"')
+    expect(sidebarSource).toContain('studio-mobile-panel--left')
+    expect(shellSource).toContain('data-mobile-panel-backdrop')
+  })
+})

--- a/src/components/studio/studio-shell/client/mobile-panels.test.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.test.ts
@@ -45,7 +45,9 @@ describe('mobile studio navigation', () => {
 
   test('isolates an open drawer from status controls', () => {
     expect(tabBarSource).toContain('studio-topbar')
+    expect(tabBarSource).toContain('data-mobile-panel-background')
     expect(mobilePanelSource).toContain('closeVersionMenus()')
+    expect(mobilePanelSource).toContain('[data-mobile-panel-background]')
     expect(studioStyles).toContain(
       '.studio-shell[data-mobile-panel] .studio-statusbar',
     )

--- a/src/components/studio/studio-shell/client/mobile-panels.test.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.test.ts
@@ -11,6 +11,12 @@ const sidebarSource = await Bun.file(
 const runtimeRailSource = await Bun.file(
   new URL('../../runtime-rail/RuntimeRail.astro', import.meta.url),
 ).text()
+const mobilePanelSource = await Bun.file(
+  new URL('./mobile-panels.ts', import.meta.url),
+).text()
+const studioStyles = await Bun.file(
+  new URL('../../../../styles/studio.css', import.meta.url),
+).text()
 const shellSource = await Bun.file(
   new URL('../../StudioShell.astro', import.meta.url),
 ).text()
@@ -35,5 +41,13 @@ describe('mobile studio navigation', () => {
     expect(nextMobilePanel(undefined, 'sidebar')).toBe('sidebar')
     expect(nextMobilePanel('sidebar', 'rail')).toBe('rail')
     expect(nextMobilePanel('rail', 'rail')).toBeUndefined()
+  })
+
+  test('isolates an open drawer from status controls', () => {
+    expect(tabBarSource).toContain('studio-topbar')
+    expect(mobilePanelSource).toContain('closeVersionMenus()')
+    expect(studioStyles).toContain(
+      '.studio-shell[data-mobile-panel] .studio-statusbar',
+    )
   })
 })

--- a/src/components/studio/studio-shell/client/mobile-panels.test.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.test.ts
@@ -1,11 +1,15 @@
 // @ts-nocheck -- Bun's test globals are not part of the Astro app tsconfig.
 import { describe, expect, test } from 'bun:test'
+import { nextMobilePanel } from './mobile-panels'
 
 const tabBarSource = await Bun.file(
   new URL('../TabBar.astro', import.meta.url),
 ).text()
 const sidebarSource = await Bun.file(
   new URL('../Sidebar.astro', import.meta.url),
+).text()
+const runtimeRailSource = await Bun.file(
+  new URL('../../runtime-rail/RuntimeRail.astro', import.meta.url),
 ).text()
 const shellSource = await Bun.file(
   new URL('../../StudioShell.astro', import.meta.url),
@@ -18,5 +22,18 @@ describe('mobile studio navigation', () => {
     expect(sidebarSource).toContain('id="studio-sidebar"')
     expect(sidebarSource).toContain('studio-mobile-panel--left')
     expect(shellSource).toContain('data-mobile-panel-backdrop')
+  })
+
+  test('exposes the persisted runtime rail as a mobile panel', () => {
+    expect(tabBarSource).toContain('data-toggle-mobile-panel="rail"')
+    expect(tabBarSource).toContain('aria-controls="runtime-rail"')
+    expect(runtimeRailSource).toContain('data-mobile-panel-name="rail"')
+    expect(runtimeRailSource).toContain('studio-mobile-panel--right')
+  })
+
+  test('opens one panel at a time and closes the active panel', () => {
+    expect(nextMobilePanel(undefined, 'sidebar')).toBe('sidebar')
+    expect(nextMobilePanel('sidebar', 'rail')).toBe('rail')
+    expect(nextMobilePanel('rail', 'rail')).toBeUndefined()
   })
 })

--- a/src/components/studio/studio-shell/client/mobile-panels.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.ts
@@ -1,0 +1,204 @@
+type MobilePanelName = 'sidebar' | 'rail'
+
+type CloseOptions = {
+  restoreFocus?: boolean
+}
+
+const MOBILE_QUERY = '(max-width: 1023px)'
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function isMobileViewport() {
+  return window.matchMedia(MOBILE_QUERY).matches
+}
+
+function getOpenPanel(shell: HTMLElement): MobilePanelName | undefined {
+  const panel = shell.dataset.mobilePanel
+  return panel === 'sidebar' || panel === 'rail' ? panel : undefined
+}
+
+function getPanel(shell: HTMLElement, name: MobilePanelName) {
+  return shell.querySelector<HTMLElement>(`[data-mobile-panel-name="${name}"]`)
+}
+
+function getFocusableElements(panel: HTMLElement) {
+  return [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
+    (element) => !element.hidden && element.getClientRects().length > 0,
+  )
+}
+
+function syncMobilePanelState(shell: HTMLElement) {
+  const mobile = isMobileViewport()
+  const openPanel = mobile ? getOpenPanel(shell) : undefined
+
+  shell
+    .querySelectorAll<HTMLElement>('[data-toggle-mobile-panel]')
+    .forEach((toggle) => {
+      const panel = toggle.dataset.toggleMobilePanel as
+        | MobilePanelName
+        | undefined
+      const expanded = Boolean(panel && panel === openPanel)
+      toggle.setAttribute('aria-expanded', String(expanded))
+      const openLabel = toggle.dataset.openLabel
+      const closeLabel = toggle.dataset.closeLabel
+      if (openLabel && closeLabel) {
+        toggle.setAttribute('aria-label', expanded ? closeLabel : openLabel)
+      }
+    })
+
+  shell
+    .querySelectorAll<HTMLElement>('[data-mobile-panel-name]')
+    .forEach((panel) => {
+      const name = panel.dataset.mobilePanelName as MobilePanelName | undefined
+      if (!mobile) {
+        panel.removeAttribute('aria-hidden')
+        panel.removeAttribute('aria-modal')
+        panel.removeAttribute('inert')
+        panel.removeAttribute('role')
+        panel.removeAttribute('tabindex')
+        return
+      }
+
+      const expanded = Boolean(name && name === openPanel)
+      panel.setAttribute('aria-hidden', String(!expanded))
+      panel.toggleAttribute('inert', !expanded)
+      panel.setAttribute('role', 'dialog')
+      panel.setAttribute('tabindex', '-1')
+      if (expanded) panel.setAttribute('aria-modal', 'true')
+      else panel.removeAttribute('aria-modal')
+    })
+}
+
+function closeMobilePanel(
+  shell: HTMLElement,
+  { restoreFocus = true }: CloseOptions = {},
+) {
+  delete shell.dataset.mobilePanel
+  syncMobilePanelState(shell)
+
+  if (restoreFocus && window.__leohuynhMobilePanelTrigger?.isConnected) {
+    window.__leohuynhMobilePanelTrigger.focus({ preventScroll: true })
+  }
+  window.__leohuynhMobilePanelTrigger = undefined
+}
+
+function toggleMobilePanel(
+  shell: HTMLElement,
+  name: MobilePanelName,
+  trigger: HTMLElement,
+) {
+  if (!isMobileViewport()) return
+  if (getOpenPanel(shell) === name) {
+    closeMobilePanel(shell)
+    return
+  }
+
+  shell.dataset.mobilePanel = name
+  window.__leohuynhMobilePanelTrigger = trigger
+  syncMobilePanelState(shell)
+
+  const panel = getPanel(shell, name)
+  requestAnimationFrame(() => {
+    const firstFocusable = panel && getFocusableElements(panel)[0]
+    ;(firstFocusable ?? panel)?.focus({ preventScroll: true })
+  })
+}
+
+function trapPanelFocus(event: KeyboardEvent, shell: HTMLElement) {
+  const openPanel = getOpenPanel(shell)
+  const panel = openPanel && getPanel(shell, openPanel)
+  if (!panel) return
+
+  const focusable = getFocusableElements(panel)
+  if (focusable.length === 0) {
+    event.preventDefault()
+    panel.focus({ preventScroll: true })
+    return
+  }
+
+  const first = focusable[0]
+  const last = focusable.at(-1)
+  const active = document.activeElement
+  if (event.shiftKey && (active === first || !panel.contains(active))) {
+    event.preventDefault()
+    last?.focus({ preventScroll: true })
+  } else if (!event.shiftKey && (active === last || !panel.contains(active))) {
+    event.preventDefault()
+    first.focus({ preventScroll: true })
+  }
+}
+
+function bindMobilePanelListeners() {
+  if (window.__leohuynhMobilePanelsBound) return
+  window.__leohuynhMobilePanelsBound = true
+
+  document.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement
+    const toggle = target.closest<HTMLElement>('[data-toggle-mobile-panel]')
+    if (toggle) {
+      const shell = toggle.closest<HTMLElement>('.studio-shell')
+      const panel = toggle.dataset.toggleMobilePanel as
+        | MobilePanelName
+        | undefined
+      if (shell && panel) toggleMobilePanel(shell, panel, toggle)
+      return
+    }
+
+    const backdrop = target.closest<HTMLElement>('[data-mobile-panel-backdrop]')
+    if (backdrop) {
+      const shell = backdrop.closest<HTMLElement>('.studio-shell')
+      if (shell) closeMobilePanel(shell)
+      return
+    }
+
+    const panelLink = target.closest<HTMLElement>(
+      '[data-mobile-panel-name] a[href]',
+    )
+    if (panelLink) {
+      const shell = panelLink.closest<HTMLElement>('.studio-shell')
+      if (shell && getOpenPanel(shell)) {
+        closeMobilePanel(shell, { restoreFocus: false })
+      }
+    }
+  })
+
+  document.addEventListener('keydown', (event) => {
+    const shell = document.querySelector<HTMLElement>(
+      '.studio-shell[data-mobile-panel]',
+    )
+    if (!shell || !isMobileViewport()) return
+
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeMobilePanel(shell)
+    } else if (event.key === 'Tab') {
+      trapPanelFocus(event, shell)
+    }
+  })
+
+  document.addEventListener('astro:before-swap', () => {
+    document
+      .querySelectorAll<HTMLElement>('.studio-shell[data-mobile-panel]')
+      .forEach((shell) => {
+        closeMobilePanel(shell, { restoreFocus: false })
+      })
+  })
+
+  window.matchMedia(MOBILE_QUERY).addEventListener('change', () => {
+    document.querySelectorAll<HTMLElement>('.studio-shell').forEach((shell) => {
+      closeMobilePanel(shell, { restoreFocus: false })
+    })
+  })
+}
+
+export function setupMobilePanels(shell: HTMLElement) {
+  if (!isMobileViewport()) delete shell.dataset.mobilePanel
+  syncMobilePanelState(shell)
+  bindMobilePanelListeners()
+}

--- a/src/components/studio/studio-shell/client/mobile-panels.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.ts
@@ -14,6 +14,13 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',')
 
+export function nextMobilePanel(
+  current: MobilePanelName | undefined,
+  requested: MobilePanelName,
+) {
+  return current === requested ? undefined : requested
+}
+
 function isMobileViewport() {
   return window.matchMedia(MOBILE_QUERY).matches
 }
@@ -94,19 +101,19 @@ function toggleMobilePanel(
   trigger: HTMLElement,
 ) {
   if (!isMobileViewport()) return
-  if (getOpenPanel(shell) === name) {
+  const nextPanel = nextMobilePanel(getOpenPanel(shell), name)
+  if (!nextPanel) {
     closeMobilePanel(shell)
     return
   }
 
-  shell.dataset.mobilePanel = name
+  shell.dataset.mobilePanel = nextPanel
   window.__leohuynhMobilePanelTrigger = trigger
   syncMobilePanelState(shell)
 
-  const panel = getPanel(shell, name)
+  const panel = getPanel(shell, nextPanel)
   requestAnimationFrame(() => {
-    const firstFocusable = panel && getFocusableElements(panel)[0]
-    ;(firstFocusable ?? panel)?.focus({ preventScroll: true })
+    panel?.focus({ preventScroll: true })
   })
 }
 
@@ -125,10 +132,16 @@ function trapPanelFocus(event: KeyboardEvent, shell: HTMLElement) {
   const first = focusable[0]
   const last = focusable.at(-1)
   const active = document.activeElement
-  if (event.shiftKey && (active === first || !panel.contains(active))) {
+  if (
+    event.shiftKey &&
+    (active === panel || active === first || !panel.contains(active))
+  ) {
     event.preventDefault()
     last?.focus({ preventScroll: true })
-  } else if (!event.shiftKey && (active === last || !panel.contains(active))) {
+  } else if (
+    !event.shiftKey &&
+    (active === panel || active === last || !panel.contains(active))
+  ) {
     event.preventDefault()
     first.focus({ preventScroll: true })
   }

--- a/src/components/studio/studio-shell/client/mobile-panels.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.ts
@@ -47,6 +47,12 @@ function syncMobilePanelState(shell: HTMLElement) {
   const openPanel = mobile ? getOpenPanel(shell) : undefined
 
   shell
+    .querySelectorAll<HTMLElement>('[data-mobile-panel-background]')
+    .forEach((background) => {
+      background.toggleAttribute('inert', Boolean(openPanel))
+    })
+
+  shell
     .querySelectorAll<HTMLElement>('[data-toggle-mobile-panel]')
     .forEach((toggle) => {
       const panel = toggle.dataset.toggleMobilePanel as

--- a/src/components/studio/studio-shell/client/mobile-panels.ts
+++ b/src/components/studio/studio-shell/client/mobile-panels.ts
@@ -1,3 +1,5 @@
+import { closeVersionMenus } from './interactions'
+
 type MobilePanelName = 'sidebar' | 'rail'
 
 type CloseOptions = {
@@ -107,6 +109,7 @@ function toggleMobilePanel(
     return
   }
 
+  closeVersionMenus()
   shell.dataset.mobilePanel = nextPanel
   window.__leohuynhMobilePanelTrigger = trigger
   syncMobilePanelState(shell)

--- a/src/components/widgets/StatusRepository.tsx
+++ b/src/components/widgets/StatusRepository.tsx
@@ -30,7 +30,7 @@ export default function StatusRepository({
   }, [])
 
   return (
-    <div className="flex min-w-0 items-center gap-1 whitespace-nowrap text-[11px]">
+    <div className="flex min-w-0 items-center gap-1 whitespace-nowrap">
       <span className="shrink-0 text-slate-400" aria-hidden="true">
         <HugeiconsIcon icon={TerminalIcon} size={13} strokeWidth={1.9} />
       </span>

--- a/src/components/widgets/repository-cta.test.tsx
+++ b/src/components/widgets/repository-cta.test.tsx
@@ -60,5 +60,6 @@ describe('repository discovery links', () => {
     expect(html).not.toContain('sidebar-view-repo')
     expect(html).toContain('target="_blank"')
     expect(html).toContain('rel="noreferrer"')
+    expect(html).not.toContain('text-[11px]')
   })
 })

--- a/src/styles/studio.css
+++ b/src/styles/studio.css
@@ -162,7 +162,21 @@ html[data-nav-pending="true"] .nav-progress {
     transform: translateX(-100%);
   }
 
+  .studio-mobile-panel--right {
+    right: 0;
+    display: grid;
+    transform: translateX(100%);
+    box-shadow: -12px 0 28px rgb(15 23 42 / 0.14);
+  }
+
   .studio-shell[data-mobile-panel="sidebar"] .studio-mobile-panel--left {
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(0);
+    transition-delay: 0s;
+  }
+
+  .studio-shell[data-mobile-panel="rail"] .studio-mobile-panel--right {
     visibility: visible;
     pointer-events: auto;
     transform: translateX(0);

--- a/src/styles/studio.css
+++ b/src/styles/studio.css
@@ -208,6 +208,15 @@ html[data-nav-pending="true"] .nav-progress {
   .studio-shell[data-mobile-panel] [data-track-region="content"] {
     overflow: hidden;
   }
+
+  .studio-shell[data-mobile-panel] .studio-topbar,
+  .studio-shell[data-mobile-panel] .studio-statusbar {
+    pointer-events: none;
+  }
+
+  .studio-shell[data-mobile-panel] .studio-mobile-panel-toggle {
+    pointer-events: auto;
+  }
 }
 
 @media (max-width: 1023px) and (prefers-reduced-motion: reduce) {

--- a/src/styles/studio.css
+++ b/src/styles/studio.css
@@ -139,6 +139,70 @@ html[data-nav-pending="true"] .nav-progress {
   }
 }
 
+/* On narrow viewports the existing rails become off-canvas panels below the
+ * tab bar. Reusing the same DOM preserves folder state and live widget islands. */
+@media (max-width: 1023px) {
+  .studio-mobile-panel {
+    position: absolute;
+    top: 44px;
+    bottom: 0;
+    z-index: 40;
+    display: block;
+    width: min(320px, calc(100% - 48px));
+    visibility: hidden;
+    pointer-events: none;
+    box-shadow: 12px 0 28px rgb(15 23 42 / 0.14);
+    transition:
+      transform 180ms ease,
+      visibility 0s linear 180ms;
+  }
+
+  .studio-mobile-panel--left {
+    left: 0;
+    transform: translateX(-100%);
+  }
+
+  .studio-shell[data-mobile-panel="sidebar"] .studio-mobile-panel--left {
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(0);
+    transition-delay: 0s;
+  }
+
+  .studio-mobile-panel-backdrop {
+    position: absolute;
+    top: 44px;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 30;
+    visibility: hidden;
+    background: rgb(15 23 42 / 0.3);
+    opacity: 0;
+    touch-action: none;
+    transition:
+      opacity 180ms ease,
+      visibility 0s linear 180ms;
+  }
+
+  .studio-shell[data-mobile-panel] .studio-mobile-panel-backdrop {
+    visibility: visible;
+    opacity: 1;
+    transition-delay: 0s;
+  }
+
+  .studio-shell[data-mobile-panel] [data-track-region="content"] {
+    overflow: hidden;
+  }
+}
+
+@media (max-width: 1023px) and (prefers-reduced-motion: reduce) {
+  .studio-mobile-panel,
+  .studio-mobile-panel-backdrop {
+    transition: none;
+  }
+}
+
 @media (min-width: 1024px) {
   .studio-workspace {
     grid-template-columns: 260px minmax(0, 1fr) 360px;


### PR DESCRIPTION
## Summary

- add compact mobile controls for the Explorer and Runtime rail
- reuse both existing desktop rails as off-canvas drawers below `lg`
- manage exclusive panel state, backdrop/Escape/link close, focus trapping/restoration, and inert background regions
- reset panel state across viewport changes and Astro soft navigation while preserving the runtime rail
- keep the desktop three-column layout and right-rail persistence unchanged

## Verification

- `bun test` — 18 passed
- `bun run check` — 0 diagnostics
- `bun run build` — passed
- Biome on touched files — passed
- `git diff --check` — passed
- browser interaction QA — 320×600, 390×600, 768×700, 1023×700, 1024×700, desktop
  - Explorer and Runtime open independently
  - switching panels keeps only one open
  - Escape, backdrop, active toggle, and navigation close the drawer
  - focus enters the panel, stays trapped, and returns to the trigger
  - Astro `/` → `/builds` soft navigation closes the drawer and preserves/reopens the runtime rail
  - no horizontal overflow or status-bar collision

Fixes #115
