### PR TITLE
docs: document the working Oxygen deploy OOM fix (supersedes #444)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,24 @@ export const components: HydrogenComponent[] = [/* …existing, */ Video];
 - [Shopify Oxygen](https://weaverse.io/docs/deployment/oxygen) (recommended)
 - [Vercel](https://wvse.cc/deploy-pilot-to-vercel)
 
+> [!NOTE]
+> **Deploy fails with `JavaScript heap out of memory` (exit 134)?**
+>
+> The Oxygen build generates a server sourcemap (~4.6 MB here, roughly two thirds of the server output). On large storefronts that can push the CI runner past Node's default heap, and the deploy dies before uploading a complete build. The environment then serves HTML referencing assets that were never published, and the storefront renders blank.
+>
+> Set `SHOPIFY_HYDROGEN_FLAG_SOURCEMAP=false` on the deploy step of the generated workflow (`.github/workflows/oxygen-deployment-*.yml`). Add `NODE_OPTIONS` too if it still OOMs:
+>
+> ```yaml
+> - name: Build and Publish to Oxygen
+>   run: npx shopify hydrogen deploy
+>   env:
+>     SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_... }}
+>     SHOPIFY_HYDROGEN_FLAG_SOURCEMAP: "false"
+>     NODE_OPTIONS: --max-old-space-size=8192
+> ```
+>
+> This can't be fixed in `vite.config.ts`: the Shopify CLI passes `sourcemap` inline to Vite when it builds, and inline config overrides the config file. The CLI flag (or its `--no-sourcemap` equivalent) is the only lever the theme repo can document.
+
 ---
 
 ## Who's using Pilot


### PR DESCRIPTION
## Why

A client storefront hit `FATAL ERROR: JavaScript heap out of memory` (exit 134) during the Oxygen deploy. The build died before uploading completely, so the environment served HTML referencing client JS that was never published and the storefront rendered blank (all `oxygen-v2/.../assets/*.js` returned 404).

Supersedes #444, which tried to fix this with `build.sourcemap: false` in `vite.config.ts`. That does not work.

## Why the config change doesn't work

Two independent reasons, either one fatal:

**1. It was already `false`.** Asking Vite to resolve the config on unmodified `main` returns `false` for both the client and SSR passes. That's the default. #444 set a value to what it already was.

**2. The Shopify CLI overrides the config file.** The server build receives `sourcemap` inline, and deploy hardcodes it to `true`:

```js
// @shopify/cli/dist/chunk-AATUQ2AY.js
await Je({ directory: p, ..., sourcemap: !0, forceClientSourcemap: d, ... })
```

Inline config beats the config file in Vite, so the theme repo cannot turn this off from `vite.config.ts`.

Verified by building both ways:

```
main (no change):        dist/server/index.js.map  4,833,304 bytes
#444 applied:            dist/server/index.js.map  4,833,304 bytes
cmp → byte-identical
```

## What actually works

The CLI owns the flag, so use the CLI's switch. Measured on this repo:

| Build | server output | `.map` files | peak RSS |
| --- | --- | --- | --- |
| default | 6.9 MB | 1 | 1362 MB |
| `SHOPIFY_HYDROGEN_FLAG_SOURCEMAP=false` | 2.3 MB | 0 | 1136 MB |

Server bundle drops by 4.6 MB, peak memory by ~226 MB (17%). `npx shopify hydrogen build --no-sourcemap` produces the same result; the env var is documented because it drops straight into the generated workflow next to `NODE_OPTIONS`.

## Changes

README only. Documents `SHOPIFY_HYDROGEN_FLAG_SOURCEMAP=false` on the deploy step alongside the existing `NODE_OPTIONS` heap bump, and records why `vite.config.ts` can't solve it so the next person debugging an OOM doesn't retry the dead end.

No `vite.config.ts` change. No runtime behavior change.

## Verification

- `npm run biome` — 324 files, 0 warnings
- Documented env var built end-to-end: exit 0, 0 `.map` files, server 2.3 MB
