### PR TITLE
ci: build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,10 @@ jobs:
       # `sensitive: true` is the real boundary; this catches what humans missed.
       - name: Audit Weaverse settings
         run: npm run weaverse:audit
+
+      # Typecheck does not see bundler-level breakage: a bad dynamic import, a
+      # client-only module pulled into the worker bundle, or a Vite plugin
+      # misconfiguration all typecheck clean and fail at deploy. The build
+      # needs no storefront credentials, so it runs unauthenticated here.
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Why

CI runs lint, typecheck, manifest drift, and the settings audit — but never builds. A broken build merges clean and fails at Oxygen deploy, where a partial upload serves HTML referencing assets that were never published (the blank-storefront failure mode from #469).

## The gap this closes

Typecheck does not see bundler-level breakage. Realistic case: a dependency gets removed from `package.json` but its ambient module declaration is left behind in `app/types/`.

```ts
// app/types/fontsource.d.ts — declaration outlives the package
declare module "@fontsource-variable/deleted-font";
```

```ts
// app/root.tsx
import "@fontsource-variable/deleted-font";
```

Measured against every gate currently in CI:

| Gate | Result |
| --- | --- |
| `npm run biome` | pass |
| `npm run typecheck` | pass |
| `npm run weaverse:manifest:check` | pass |
| `npm run weaverse:audit` | pass |
| `npm run build` | **fail** |

```
Error: [vite]: Rolldown failed to resolve import
✗ Build failed in 659ms
```

TypeScript trusts the ambient declaration, so the module resolves at type level and never at bundle level. Same shape as a client-only module pulled into the worker bundle or a Vite plugin misconfiguration: clean types, broken artifact.

## Credentials

None needed. Verified the build succeeds with an empty environment (`env -i`) and no `.env` present, so this runs unauthenticated on PRs from forks.

## Cost

~30s on this machine. The step reuses the `npm ci` and setup-node cache already in the job.
