### PR TITLE
Fix Spotify last-played alignment

### DIFF
--- a/src/components/studio/runtime-rail/SpotifyCard.astro
+++ b/src/components/studio/runtime-rail/SpotifyCard.astro
@@ -31,7 +31,10 @@ import SpotifyIcon from '@icons/spotify.svg?raw'
       ></a>
       <b data-spotify-empty>—</b>
       <span data-spotify-artist class="block font-mono text-xs text-muted">loading…</span>
-      <span class="mt-1 flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-code-green">
+      <span
+        data-spotify-status-row
+        class="mt-1 flex items-center font-mono text-[10px] uppercase tracking-[0.08em] text-code-green"
+      >
         <span data-spotify-eq class="eq" aria-hidden="true">
           <span></span>
           <span></span>

--- a/src/components/studio/runtime-rail/spotify-card-layout.test.ts
+++ b/src/components/studio/runtime-rail/spotify-card-layout.test.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck -- Bun's test globals are not part of the Astro app tsconfig.
+import { describe, expect, test } from 'bun:test'
+
+const cardSource = await Bun.file(
+  new URL('./SpotifyCard.astro', import.meta.url),
+).text()
+const animationStyles = await Bun.file(
+  new URL('../../../styles/animations.css', import.meta.url),
+).text()
+
+function cssRule(selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return (
+    animationStyles.match(
+      new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`),
+    )?.[1] ?? ''
+  )
+}
+
+describe('Spotify card status layout', () => {
+  test('reserves equalizer spacing only while Spotify is playing', () => {
+    const statusRow = cardSource.match(
+      /<span[^>]*data-spotify-status-row[^>]*class="([^"]+)"/,
+    )?.[1]
+
+    expect(statusRow).toBeDefined()
+    expect(statusRow).not.toMatch(/\bgap-/)
+    expect(cssRule('.eq')).toContain('inline-size: 0')
+    expect(cssRule('.eq.is-playing')).toContain('inline-size: 18px')
+    expect(cssRule('.eq.is-playing')).toContain('margin-inline-end: 6px')
+  })
+})

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -22,14 +22,19 @@
   display: inline-flex;
   visibility: hidden;
   opacity: 0;
+  flex: 0 0 auto;
   align-items: flex-end;
   gap: 2px;
+  inline-size: 0;
   height: 14px;
+  overflow: hidden;
 }
 
 .eq.is-playing {
   visibility: visible;
   opacity: 1;
+  inline-size: 18px;
+  margin-inline-end: 6px;
 }
 
 .eq span {


### PR DESCRIPTION
Fix the Spotify runtime status alignment when the equalizer is inactive.

- Collapse equalizer spacing for last-played and unavailable states.
- Preserve the current now-playing wave animation and spacing.
- Add regression coverage for the layout contract.

Preview: https://leohuynh-k8dtepydz-hta218.vercel.app/

Closes #118
